### PR TITLE
Client: Loader component, setState && useEffect func fix

### DIFF
--- a/client/src/components/ActiveTasks/ActiveTasks.jsx
+++ b/client/src/components/ActiveTasks/ActiveTasks.jsx
@@ -7,9 +7,10 @@ import {
 } from '../../api/taskApi';
 
 import ToDoItem from '../ToDoItem';
-import DeleteAllButton from '../DeleteAllButton';
 import CreateTaskButton from '../CreateTaskButton';
 import AddTaskModal from '../AddTaskModal';
+import DeleteAllButton from '../DeleteAllButton';
+import Loader from '../Loader';
 
 import { Plus } from 'lucide-react';
 
@@ -17,17 +18,25 @@ import styles from './ActiveTasks.module.css';
 
 const ActiveTasks = () => {
 	const [tasks, setTasks] = useState([]);
+	const [loading, setLoading] = useState(true);
 	const activeTasks = tasks.filter((task) => !task.done);
 	const [showCreateModal, setShowCreateModal] = useState(false);
 	const [activePomodoroId, setActivePomodoroId] = useState(null);
 
 	const loadTasks = async () => {
+		setLoading(true);
+
 		const data = await fetchTasks();
 		setTasks(data);
+		setLoading(false);
 	};
 
 	useEffect(() => {
-		loadTasks();
+		(async () => {
+			const data = await fetchTasks();
+			setTasks(data);
+			setLoading(false);
+		})();
 	}, []);
 
 	const addTask = async ({ title, description }) => {
@@ -67,6 +76,8 @@ const ActiveTasks = () => {
 
 	return (
 		<div className={styles.container}>
+			{loading && <Loader />}
+
 			<div className={styles.activeHeader}>
 				<h2 className={styles.activeTasksCount}>Active tasks ({activeTasks.length})</h2>
 				<DeleteAllButton onClick={deleteAllActive} />

--- a/client/src/components/ActiveTasks/ActiveTasks.module.css
+++ b/client/src/components/ActiveTasks/ActiveTasks.module.css
@@ -1,4 +1,5 @@
 .container {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	height: 100%;

--- a/client/src/components/CompletedTasks/CompletedTasks.jsx
+++ b/client/src/components/CompletedTasks/CompletedTasks.jsx
@@ -3,19 +3,28 @@ import { fetchTasks, updateTask as apiUpdateTask, deleteTask as apiDeleteTask } 
 
 import ToDoItem from '../ToDoItem';
 import DeleteAllButton from '../DeleteAllButton';
+import Loader from '../Loader';
 
 import styles from './CompletedTasks.module.css';
 
 const CompletedTasks = () => {
 	const [tasks, setTasks] = useState([]);
+	const [loading, setLoading] = useState(true);
 
 	const loadTasks = async () => {
+		setLoading(true);
+
 		const data = await fetchTasks();
 		setTasks(data);
+		setLoading(false);
 	};
 
 	useEffect(() => {
-		loadTasks();
+		(async () => {
+			const data = await fetchTasks();
+			setTasks(data);
+			setLoading(false);
+		})();
 	}, []);
 
 	const completedTasks = tasks.filter((task) => task.done);
@@ -46,8 +55,11 @@ const CompletedTasks = () => {
 
 		await loadTasks();
 	};
+
 	return (
 		<div className={styles.container}>
+			{loading && <Loader />}
+
 			<div className={styles.activeHeader}>
 				<h2 className={styles.activeTasksCount}>Completed tasks ({completedTasks.length})</h2>
 				<DeleteAllButton onClick={deleteAllCompleted} />

--- a/client/src/components/CompletedTasks/CompletedTasks.module.css
+++ b/client/src/components/CompletedTasks/CompletedTasks.module.css
@@ -1,4 +1,5 @@
 .container {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 	height: 100%;

--- a/client/src/components/Loader/Loader.jsx
+++ b/client/src/components/Loader/Loader.jsx
@@ -1,0 +1,11 @@
+import styles from './Loader.module.css';
+
+export const Loader = () => {
+	return (
+		<div className={styles.backdrop}>
+			<span className={styles.loader}></span>
+		</div>
+	);
+};
+
+export default Loader;

--- a/client/src/components/Loader/Loader.module.css
+++ b/client/src/components/Loader/Loader.module.css
@@ -1,0 +1,49 @@
+.backdrop {
+	position: absolute;
+	inset: 0;
+	z-index: 999;
+	display: flex;
+	justify-content: center;
+  align-items: center;
+}
+
+.loader {
+	width: 68px;
+	height: 68px;
+	border-radius: 50%;
+	position: relative;
+	animation: rotate 1s linear infinite;
+}
+.loader::before {
+	content: '';
+	box-sizing: border-box;
+	position: absolute;
+	inset: 0px;
+	border-radius: 50%;
+	border: 5px solid #fff;
+	animation: prixClipFix 2s linear infinite;
+}
+
+@keyframes rotate {
+	100% {
+		transform: rotate(360deg);
+	}
+}
+
+@keyframes prixClipFix {
+	0% {
+		clip-path: polygon(50% 50%, 0 0, 0 0, 0 0, 0 0, 0 0);
+	}
+	25% {
+		clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 0, 100% 0, 100% 0);
+	}
+	50% {
+		clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 100% 100%, 100% 100%);
+	}
+	75% {
+		clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 100%);
+	}
+	100% {
+		clip-path: polygon(50% 50%, 0 0, 100% 0, 100% 100%, 0 100%, 0 0);
+	}
+}

--- a/client/src/components/Loader/index.jsx
+++ b/client/src/components/Loader/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './Loader.jsx';


### PR DESCRIPTION
Fix dla jednoczesnego renderowania ActiveTasks i CompletedTasks setState i useEffect.  Obecna wariacja wygląda tak:

```
const loadTasks = async () => {
		setLoading(true);

		const data = await fetchTasks();
		setTasks(data);
		setLoading(false);
	};

	useEffect(() => {
		(async () => {
			const data = await fetchTasks();
			setTasks(data);
			setLoading(false);
		})();
	}, []);
```

Nie powoduje to jednoczesnego renderowania, ale idealne też nie jest bo powtarza się w tych dwóch komponentach, czym troszkę łamie zasadę DRY i przydałby się custom hook. Ale na razie to jeszcze nie mój poziom :D Docelowo dodam w przyszłości.

Został dodany component Loader (pobrałem gotowy z cssloaders.github.io). 

Jest on pokazywany if loading(true).

W komponencie będzie to wyuglądało jak na screenie:

<img width="1491" height="875" alt="Zrzut ekranu 2026-03-11 203047" src="https://github.com/user-attachments/assets/f8ab2683-0665-402b-8e69-7024c6c6c1e7" />

Przy normalnej pracy raczej loadera nie zobaczymy bo u mnie cała aplikacja śmiga jak na Formule1 :D Musiałem sztucznie opóźnić loading dzięki setInterval aby zrobić screena.

koncola czysta - eslint nie krzyczy - wydajność zabezpieczona i UX poprawiony - użytkownik będzie wiedział że coś się dzieje dzięki Loaderowi 💪 
