### PR TITLE
Client/categories

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,9 +8,8 @@
       "name": "nexttodo-client",
       "version": "0.0.0",
       "dependencies": {
-        "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^10.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
+        "@dnd-kit/helpers": "^0.4.0",
+        "@dnd-kit/react": "^0.4.0",
         "lucide-react": "^0.562.0",
         "react": "^19.2.0",
         "react-day-picker": "^9.13.0",
@@ -499,58 +498,85 @@
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
     },
-    "node_modules/@dnd-kit/accessibility": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
-      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+    "node_modules/@dnd-kit/abstract": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/abstract/-/abstract-0.4.0.tgz",
+      "integrity": "sha512-loEEJxKT5oLOLeRBJVTO9qpgvvW/Qq902xO20v1JMbpANuN/NLurUdpxIwNpVz+RtOSyzznnbc7lO7psmOhc9A==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
+        "@dnd-kit/geometry": "^0.4.0",
+        "@dnd-kit/state": "^0.4.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@dnd-kit/core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
-      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+    "node_modules/@dnd-kit/collision": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/collision/-/collision-0.4.0.tgz",
+      "integrity": "sha512-oOHHUkH1h9Vl2m8TwLw/mPHA7Blf+s0PYcRoLNWNBVxDzugJKZo8WdpU58EMu9qkqyQGrR/YTOozGiMPhlqZ5Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@dnd-kit/accessibility": "^3.1.1",
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "@dnd-kit/abstract": "^0.4.0",
+        "@dnd-kit/geometry": "^0.4.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@dnd-kit/sortable": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
-      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+    "node_modules/@dnd-kit/dom": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/dom/-/dom-0.4.0.tgz",
+      "integrity": "sha512-mJDKt0BtlHXetZyrvZXh6++aycleIbYWH/OVC4nlszDh8NvW7q8dfsxFllR5RtLKLcykLaI4o545Figfks/HZQ==",
       "license": "MIT",
       "dependencies": {
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.3.0",
-        "react": ">=16.8.0"
+        "@dnd-kit/abstract": "^0.4.0",
+        "@dnd-kit/collision": "^0.4.0",
+        "@dnd-kit/geometry": "^0.4.0",
+        "@dnd-kit/state": "^0.4.0",
+        "tslib": "^2.6.2"
       }
     },
-    "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+    "node_modules/@dnd-kit/geometry": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/geometry/-/geometry-0.4.0.tgz",
+      "integrity": "sha512-d1n+CU54V/qF/g792bmJK2oR4f5jOL7Pls2IfC+j9f5UBECpjsYbcPZ/krom/z8LgieqvMh1qrUkdcBjJJ7vpg==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.0.0"
+        "@dnd-kit/state": "^0.4.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/helpers": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/helpers/-/helpers-0.4.0.tgz",
+      "integrity": "sha512-9YOKevD6zOwKVvV4k3fQL//NF+UaN92sfqPpJhT0/7Jq5PLtfD+CTpzmFAjTt5o1qQpFj3xqjWnQl25ooW62wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.4.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/react": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/react/-/react-0.4.0.tgz",
+      "integrity": "sha512-J2/N4CpQf98zJBZhMljDNsc+QR4VtUKU9BRO1+Di4OGaB1qafMC4qZ11xKXOkjw+d7h82FRSXmXCo0c8+VWaWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.4.0",
+        "@dnd-kit/dom": "^0.4.0",
+        "@dnd-kit/state": "^0.4.0",
+        "tslib": "^2.6.2"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/state": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/state/-/state-0.4.0.tgz",
+      "integrity": "sha512-vVdwOY9VsYdMNa7Z0xQhTXlzHqCcCugGuoM1kzvZhnZ0tYVPRdmIhWfeO6Y2ZoN92JwYAyJRRNl4ICkEe2mneg==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.10.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1270,6 +1296,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.1.tgz",
+      "integrity": "sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,9 @@
       "name": "nexttodo-client",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "lucide-react": "^0.562.0",
         "react": "^19.2.0",
         "react-day-picker": "^9.13.0",
@@ -495,6 +498,60 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -4044,6 +4101,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,9 +13,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
+    "@dnd-kit/helpers": "^0.4.0",
+    "@dnd-kit/react": "^0.4.0",
     "lucide-react": "^0.562.0",
     "react": "^19.2.0",
     "react-day-picker": "^9.13.0",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "lucide-react": "^0.562.0",
     "react": "^19.2.0",
     "react-day-picker": "^9.13.0",

--- a/client/src/api/categoryApi.ts
+++ b/client/src/api/categoryApi.ts
@@ -1,0 +1,72 @@
+import type { Category, Task } from '../types';
+
+const API = `${import.meta.env.VITE_API_URL}/api/category`;
+
+interface ServerTask {
+  id: number;
+  taskName: string;
+  taskDesc: string;
+  isFinished: boolean;
+  scheduled: string | null;
+  created: string;
+  categoryId: number | null;
+  category: Category | null;
+}
+
+export async function fetchCategories(): Promise<Category[]> {
+  const res = await fetch(API, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!res.ok) return [];
+  return res.json() as Promise<Category[]>;
+}
+
+export async function createCategory(name: string, color: string, icon: string): Promise<void> {
+  await fetch(API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ name, color, icon }),
+  });
+}
+
+export async function updateCategory(
+  categoryId: number,
+  data: Partial<{ name: string; color: string; icon: string }>,
+): Promise<void> {
+  await fetch(API, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ category_id: categoryId, data }),
+  });
+}
+
+export async function deleteCategory(categoryId: number): Promise<void> {
+  await fetch(API, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ category_id: categoryId }),
+  });
+}
+
+export async function fetchTasksByCategory(categoryId: number): Promise<Task[]> {
+  const res = await fetch(`${API}/tasks?category_id=${categoryId}`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!res.ok) return [];
+  const data = (await res.json()) as ServerTask[];
+  return data.map((task) => ({
+    id: task.id,
+    title: task.taskName,
+    description: task.taskDesc,
+    done: task.isFinished,
+    scheduled: task.scheduled,
+    created: task.created,
+    categoryId: task.categoryId,
+    category: task.category,
+  }));
+}

--- a/client/src/api/categoryApi.ts
+++ b/client/src/api/categoryApi.ts
@@ -11,6 +11,7 @@ interface ServerTask {
   created: string;
   categoryId: number | null;
   category: Category | null;
+  sortOrder?: number;
 }
 
 export async function fetchCategories(): Promise<Category[]> {
@@ -68,5 +69,6 @@ export async function fetchTasksByCategory(categoryId: number): Promise<Task[]> 
     created: task.created,
     categoryId: task.categoryId,
     category: task.category,
+    sortOrder: task.sortOrder ?? 0,
   }));
 }

--- a/client/src/api/taskApi.ts
+++ b/client/src/api/taskApi.ts
@@ -11,6 +11,7 @@ interface ServerTask {
   created: string;
   categoryId?: number | null;
   category?: import('../types').Category | null;
+  sortOrder?: number;
 }
 
 interface TaskUpdate {
@@ -38,6 +39,7 @@ export async function fetchTasks(): Promise<Task[]> {
     created: task.created,
     categoryId: task.categoryId ?? null,
     category: task.category ?? null,
+    sortOrder: task.sortOrder ?? 0,
   }));
 }
 
@@ -74,6 +76,17 @@ export async function editTask(id: number, updates: TaskUpdate): Promise<void> {
     body: JSON.stringify({
       task_id: id,
       data: mapped,
+    }),
+  });
+}
+
+export async function reorderTasks(items: { id: number; sortOrder: number }[]): Promise<void> {
+  await fetch(`${API}/reorder`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({
+      items: items.map((i) => ({ task_id: i.id, sort_order: i.sortOrder })),
     }),
   });
 }

--- a/client/src/api/taskApi.ts
+++ b/client/src/api/taskApi.ts
@@ -9,6 +9,8 @@ interface ServerTask {
   isFinished: boolean;
   scheduled: string | null;
   created: string;
+  categoryId?: number | null;
+  category?: import('../types').Category | null;
 }
 
 interface TaskUpdate {
@@ -16,6 +18,7 @@ interface TaskUpdate {
   description?: string;
   scheduled?: string | null;
   isFinished?: boolean;
+  categoryId?: number | null;
 }
 
 export async function fetchTasks(): Promise<Task[]> {
@@ -33,11 +36,13 @@ export async function fetchTasks(): Promise<Task[]> {
     done: task.isFinished,
     scheduled: task.scheduled,
     created: task.created,
+    categoryId: task.categoryId ?? null,
+    category: task.category ?? null,
   }));
 }
 
-export async function addTask(title: string, description: string): Promise<void> {
-  await fetch(API, {
+export async function addTask(title: string, description: string): Promise<{ id: number } | null> {
+  const res = await fetch(API, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
@@ -46,6 +51,11 @@ export async function addTask(title: string, description: string): Promise<void>
       task_desc: description,
     }),
   });
+  try {
+    return (await res.json()) as { id: number };
+  } catch {
+    return null;
+  }
 }
 
 export async function editTask(id: number, updates: TaskUpdate): Promise<void> {
@@ -54,6 +64,7 @@ export async function editTask(id: number, updates: TaskUpdate): Promise<void> {
     ...(updates.description !== undefined && { taskDesc: updates.description }),
     ...(updates.scheduled !== undefined && { scheduled: updates.scheduled }),
     ...(updates.isFinished !== undefined && { isFinished: updates.isFinished }),
+    ...(updates.categoryId !== undefined && { categoryId: updates.categoryId }),
   };
 
   await fetch(API, {

--- a/client/src/components/ActiveTasks/ActiveTasks.module.css
+++ b/client/src/components/ActiveTasks/ActiveTasks.module.css
@@ -24,6 +24,21 @@
 	align-items: center;
 }
 
+.dragOverlay {
+	background-color: var(--bg-todo-item);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	padding: 6px 10px;
+	height: 48.4px;
+	display: flex;
+	align-items: center;
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--color-dark-1);
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+	cursor: grabbing;
+}
+
 .tasksList {
 	flex: 1;
 	overflow-y: auto;

--- a/client/src/components/ActiveTasks/ActiveTasks.tsx
+++ b/client/src/components/ActiveTasks/ActiveTasks.tsx
@@ -8,9 +8,9 @@ import {
 } from '../../api/taskApi';
 import { fetchTasksByCategory } from '../../api/categoryApi';
 import type { Task, PomoData, Category } from '../../types';
-import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragOverlay } from '@dnd-kit/core';
-import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
-import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import { DragDropProvider, DragOverlay } from '@dnd-kit/react';
+import type { DragEndEvent } from '@dnd-kit/react';
+import { move } from '@dnd-kit/helpers';
 
 import ToDoItem from '../ToDoItem';
 import CreateTaskButton from '../CreateTaskButton';
@@ -41,34 +41,19 @@ const ActiveTasks = ({
 }: ActiveTasksProps) => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
-  const [draggedTask, setDraggedTask] = useState<Task | null>(null);
   const activeTasks = tasks.filter((task) => !task.done).sort((a, b) => a.sortOrder - b.sortOrder);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  );
-
-  const handleDragStart = (event: DragStartEvent) => {
-    setDraggedTask(activeTasks.find((t) => t.id === event.active.id) ?? null);
-  };
-
   const handleDragEnd = async (event: DragEndEvent) => {
-    setDraggedTask(null);
-    const { active, over } = event;
-    if (!over || active.id === over.id) return;
-
-    const oldIndex = activeTasks.findIndex((t) => t.id === active.id);
-    const newIndex = activeTasks.findIndex((t) => t.id === over.id);
-    const reordered = arrayMove(activeTasks, oldIndex, newIndex);
+    if (event.canceled) return;
+    const reordered = move(activeTasks, event) as typeof activeTasks;
+    if (reordered === activeTasks) return;
 
     setTasks((prev) => {
       const completed = prev.filter((t) => t.done);
       return [...reordered.map((t, i) => ({ ...t, sortOrder: i })), ...completed];
     });
-
     await reorderTasks(reordered.map((t, i) => ({ id: t.id, sortOrder: i })));
   };
 
@@ -179,43 +164,45 @@ const ActiveTasks = ({
             </div>
           </div>
         ) : (
-          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-            <SortableContext items={activeTasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
-              {activeTasks.map((task) => (
-                <ToDoItem
-                  key={task.id}
-                  task={task}
-                  onToggle={toggleTask}
-                  onDelete={deleteTask}
-                  onEdit={updateTask}
-                  activePomodoroId={activePomodoroId}
-                  setActivePomodoroId={setActivePomodoroId}
-                  activePomoData={activePomoData}
-                  setActivePomoData={setActivePomoData}
-                  categories={categories}
-                />
-              ))}
-            </SortableContext>
+          <DragDropProvider onDragEnd={handleDragEnd}>
+            {activeTasks.map((task, index) => (
+              <ToDoItem
+                key={task.id}
+                task={task}
+                index={index}
+                draggable
+                onToggle={toggleTask}
+                onDelete={deleteTask}
+                onEdit={updateTask}
+                activePomodoroId={activePomodoroId}
+                setActivePomodoroId={setActivePomodoroId}
+                activePomoData={activePomoData}
+                setActivePomoData={setActivePomoData}
+                categories={categories}
+              />
+            ))}
             <DragOverlay dropAnimation={null}>
-              {draggedTask ? (
-                <div
-                  className={styles.dragOverlay}
-                  style={{
-                    backgroundImage: (() => {
-                      const cat = categories.find((c) => c.id === draggedTask.categoryId) ?? draggedTask.category ?? null;
-                      if (!cat) return undefined;
+              {(source) => {
+                const task = activeTasks.find((t) => t.id === source.id);
+                if (!task) return null;
+                const cat = categories.find((c) => c.id === task.categoryId) ?? task.category ?? null;
+                const backgroundImage = cat
+                  ? (() => {
                       const hex = cat.color.replace('#', '');
                       const r = parseInt(hex.slice(0, 2), 16);
                       const g = parseInt(hex.slice(2, 4), 16);
                       const b = parseInt(hex.slice(4, 6), 16);
                       return `linear-gradient(to left, rgba(${r},${g},${b},0.3) 0%, transparent 65%)`;
-                    })(),
-                  }}>
-                  {draggedTask.title}
-                </div>
-              ) : null}
+                    })()
+                  : undefined;
+                return (
+                  <div className={styles.dragOverlay} style={{ backgroundImage }}>
+                    {task.title}
+                  </div>
+                );
+              }}
             </DragOverlay>
-          </DndContext>
+          </DragDropProvider>
         )}
       </div>
 

--- a/client/src/components/ActiveTasks/ActiveTasks.tsx
+++ b/client/src/components/ActiveTasks/ActiveTasks.tsx
@@ -8,8 +8,8 @@ import {
 } from '../../api/taskApi';
 import { fetchTasksByCategory } from '../../api/categoryApi';
 import type { Task, PomoData, Category } from '../../types';
-import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
-import type { DragEndEvent } from '@dnd-kit/core';
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors, DragOverlay } from '@dnd-kit/core';
+import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 
 import ToDoItem from '../ToDoItem';
@@ -41,6 +41,7 @@ const ActiveTasks = ({
 }: ActiveTasksProps) => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
+  const [draggedTask, setDraggedTask] = useState<Task | null>(null);
   const activeTasks = tasks.filter((task) => !task.done).sort((a, b) => a.sortOrder - b.sortOrder);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -50,7 +51,12 @@ const ActiveTasks = ({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
+  const handleDragStart = (event: DragStartEvent) => {
+    setDraggedTask(activeTasks.find((t) => t.id === event.active.id) ?? null);
+  };
+
   const handleDragEnd = async (event: DragEndEvent) => {
+    setDraggedTask(null);
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
@@ -173,7 +179,7 @@ const ActiveTasks = ({
             </div>
           </div>
         ) : (
-          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
             <SortableContext items={activeTasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
               {activeTasks.map((task) => (
                 <ToDoItem
@@ -190,6 +196,25 @@ const ActiveTasks = ({
                 />
               ))}
             </SortableContext>
+            <DragOverlay dropAnimation={null}>
+              {draggedTask ? (
+                <div
+                  className={styles.dragOverlay}
+                  style={{
+                    backgroundImage: (() => {
+                      const cat = categories.find((c) => c.id === draggedTask.categoryId) ?? draggedTask.category ?? null;
+                      if (!cat) return undefined;
+                      const hex = cat.color.replace('#', '');
+                      const r = parseInt(hex.slice(0, 2), 16);
+                      const g = parseInt(hex.slice(2, 4), 16);
+                      const b = parseInt(hex.slice(4, 6), 16);
+                      return `linear-gradient(to left, rgba(${r},${g},${b},0.3) 0%, transparent 65%)`;
+                    })(),
+                  }}>
+                  {draggedTask.title}
+                </div>
+              ) : null}
+            </DragOverlay>
           </DndContext>
         )}
       </div>

--- a/client/src/components/ActiveTasks/ActiveTasks.tsx
+++ b/client/src/components/ActiveTasks/ActiveTasks.tsx
@@ -5,7 +5,8 @@ import {
   editTask as apiEditTask,
   deleteTask as apiDeleteTask,
 } from '../../api/taskApi';
-import type { Task, PomoData } from '../../types';
+import { fetchTasksByCategory } from '../../api/categoryApi';
+import type { Task, PomoData, Category } from '../../types';
 
 import ToDoItem from '../ToDoItem';
 import CreateTaskButton from '../CreateTaskButton';
@@ -22,6 +23,8 @@ interface ActiveTasksProps {
   setActivePomodoroId: (id: number | null) => void;
   activePomoData: PomoData | null;
   setActivePomoData: (data: PomoData | null) => void;
+  categories: Category[];
+  selectedCategoryId: number | null;
 }
 
 const ActiveTasks = ({
@@ -29,6 +32,8 @@ const ActiveTasks = ({
   setActivePomodoroId,
   activePomoData,
   setActivePomoData,
+  categories,
+  selectedCategoryId,
 }: ActiveTasksProps) => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
@@ -39,7 +44,10 @@ const ActiveTasks = ({
   const loadTasks = async () => {
     setLoading(true);
     try {
-      const data = await fetchTasks();
+      const data =
+        selectedCategoryId !== null
+          ? await fetchTasksByCategory(selectedCategoryId)
+          : await fetchTasks();
       setTasks(data);
     } finally {
       setLoading(false);
@@ -47,19 +55,23 @@ const ActiveTasks = ({
   };
 
   useEffect(() => {
-    (async () => {
-      try {
-        const data = await fetchTasks();
-        setTasks(data);
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, []);
+    loadTasks();
+  }, [selectedCategoryId]);
 
-  const addTask = async ({ title, description }: { title: string; description: string }) => {
+  const addTask = async ({
+    title,
+    description,
+    categoryId,
+  }: {
+    title: string;
+    description: string;
+    categoryId: number | null;
+  }) => {
     try {
-      await apiAddTask(title, description);
+      const created = await apiAddTask(title, description);
+      if (categoryId !== null && created?.id) {
+        await apiEditTask(created.id, { categoryId });
+      }
     } finally {
       await loadTasks();
     }
@@ -101,13 +113,18 @@ const ActiveTasks = ({
     }
   };
 
+  const activeCategory = categories.find((c) => c.id === selectedCategoryId);
+  const headerLabel = activeCategory
+    ? `${activeCategory.name} (${activeTasks.length})`
+    : `Active tasks (${activeTasks.length})`;
+
   return (
     <div className={styles.container}>
       {loading && <Loader />}
 
       {activeTasks.length > 0 && (
         <div className={styles.activeHeader}>
-          <h2 className={styles.activeTasksCount}>Active tasks ({activeTasks.length})</h2>
+          <h2 className={styles.activeTasksCount}>{headerLabel}</h2>
           <DeleteAllButton onClick={() => setShowDeleteModal(true)} />
         </div>
       )}
@@ -133,6 +150,7 @@ const ActiveTasks = ({
               setActivePomodoroId={setActivePomodoroId}
               activePomoData={activePomoData}
               setActivePomoData={setActivePomoData}
+              categories={categories}
             />
           ))
         )}
@@ -144,7 +162,14 @@ const ActiveTasks = ({
         </CreateTaskButton>
       </div>
 
-      {showCreateModal && <AddTaskModal onAdd={addTask} onClose={() => setShowCreateModal(false)} />}
+      {showCreateModal && (
+        <AddTaskModal
+          onAdd={addTask}
+          onClose={() => setShowCreateModal(false)}
+          categories={categories}
+          defaultCategoryId={selectedCategoryId}
+        />
+      )}
 
       {showDeleteModal && (
         <DeleteAllModal

--- a/client/src/components/ActiveTasks/ActiveTasks.tsx
+++ b/client/src/components/ActiveTasks/ActiveTasks.tsx
@@ -4,9 +4,13 @@ import {
   addTask as apiAddTask,
   editTask as apiEditTask,
   deleteTask as apiDeleteTask,
+  reorderTasks,
 } from '../../api/taskApi';
 import { fetchTasksByCategory } from '../../api/categoryApi';
 import type { Task, PomoData, Category } from '../../types';
+import { DndContext, closestCenter, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import type { DragEndEvent } from '@dnd-kit/core';
+import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 
 import ToDoItem from '../ToDoItem';
 import CreateTaskButton from '../CreateTaskButton';
@@ -37,9 +41,30 @@ const ActiveTasks = ({
 }: ActiveTasksProps) => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
-  const activeTasks = tasks.filter((task) => !task.done);
+  const activeTasks = tasks.filter((task) => !task.done).sort((a, b) => a.sortOrder - b.sortOrder);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = activeTasks.findIndex((t) => t.id === active.id);
+    const newIndex = activeTasks.findIndex((t) => t.id === over.id);
+    const reordered = arrayMove(activeTasks, oldIndex, newIndex);
+
+    setTasks((prev) => {
+      const completed = prev.filter((t) => t.done);
+      return [...reordered.map((t, i) => ({ ...t, sortOrder: i })), ...completed];
+    });
+
+    await reorderTasks(reordered.map((t, i) => ({ id: t.id, sortOrder: i })));
+  };
 
   const loadTasks = async () => {
     setLoading(true);
@@ -148,20 +173,24 @@ const ActiveTasks = ({
             </div>
           </div>
         ) : (
-          activeTasks.map((task) => (
-            <ToDoItem
-              key={task.id}
-              task={task}
-              onToggle={toggleTask}
-              onDelete={deleteTask}
-              onEdit={updateTask}
-              activePomodoroId={activePomodoroId}
-              setActivePomodoroId={setActivePomodoroId}
-              activePomoData={activePomoData}
-              setActivePomoData={setActivePomoData}
-              categories={categories}
-            />
-          ))
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+            <SortableContext items={activeTasks.map((t) => t.id)} strategy={verticalListSortingStrategy}>
+              {activeTasks.map((task) => (
+                <ToDoItem
+                  key={task.id}
+                  task={task}
+                  onToggle={toggleTask}
+                  onDelete={deleteTask}
+                  onEdit={updateTask}
+                  activePomodoroId={activePomodoroId}
+                  setActivePomodoroId={setActivePomodoroId}
+                  activePomoData={activePomoData}
+                  setActivePomoData={setActivePomoData}
+                  categories={categories}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
         )}
       </div>
 

--- a/client/src/components/ActiveTasks/ActiveTasks.tsx
+++ b/client/src/components/ActiveTasks/ActiveTasks.tsx
@@ -134,8 +134,17 @@ const ActiveTasks = ({
           <div className={styles.emptyState}>
             <div className={styles.emptyContainer}>
               <Search size={68} />
-              <h3>No active tasks</h3>
-              <p>Create your first task to get started</p>
+              {selectedCategoryId !== null ? (
+                <>
+                  <h3>No tasks in this category</h3>
+                  <p>Add this category to an existing task or create a new one</p>
+                </>
+              ) : (
+                <>
+                  <h3>No active tasks</h3>
+                  <p>Create your first task to get started</p>
+                </>
+              )}
             </div>
           </div>
         ) : (

--- a/client/src/components/AddTaskModal/AddTaskModal.tsx
+++ b/client/src/components/AddTaskModal/AddTaskModal.tsx
@@ -1,15 +1,19 @@
 import { useState } from 'react';
 import { X, Plus, AlertCircle } from 'lucide-react';
+import type { Category } from '../../types';
 import styles from './AddTaskModal.module.css';
 
 interface AddTaskModalProps {
-  onAdd: (task: { title: string; description: string }) => void;
+  onAdd: (task: { title: string; description: string; categoryId: number | null }) => void;
   onClose: () => void;
+  categories: Category[];
+  defaultCategoryId?: number | null;
 }
 
-const AddTaskModal = ({ onAdd, onClose }: AddTaskModalProps) => {
+const AddTaskModal = ({ onAdd, onClose, categories, defaultCategoryId }: AddTaskModalProps) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [categoryId, setCategoryId] = useState<number | null>(defaultCategoryId ?? null);
   const [inputError, setInputError] = useState('');
   const [serverError, setServerError] = useState('');
 
@@ -35,10 +39,11 @@ const AddTaskModal = ({ onAdd, onClose }: AddTaskModalProps) => {
       return;
     }
 
-    onAdd({ title, description });
+    onAdd({ title, description, categoryId });
 
     setTitle('');
     setDescription('');
+    setCategoryId(null);
     setInputError('');
     setServerError('');
     onClose();
@@ -92,6 +97,23 @@ const AddTaskModal = ({ onAdd, onClose }: AddTaskModalProps) => {
               placeholder='Enter description...'
             />
           </div>
+
+          {categories.length > 0 && (
+            <div className={styles.inputGroup}>
+              <label>Category (optional)</label>
+              <select
+                className={styles.input}
+                value={categoryId ?? ''}
+                onChange={(e) => setCategoryId(e.target.value ? Number(e.target.value) : null)}>
+                <option value=''>No category</option>
+                {categories.map((cat) => (
+                  <option key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           <div className={styles.footer}>
             <button type='button' onClick={onClose} className={`${styles.btn} ${styles.cancel}`}>

--- a/client/src/components/AddTaskModal/__tests__/AddTaskModal.test.tsx
+++ b/client/src/components/AddTaskModal/__tests__/AddTaskModal.test.tsx
@@ -7,7 +7,7 @@ import AddTaskModal from '../AddTaskModal';
 function setup() {
   const onAdd = vi.fn();
   const onClose = vi.fn();
-  render(<AddTaskModal onAdd={onAdd} onClose={onClose} />);
+  render(<AddTaskModal onAdd={onAdd} onClose={onClose} categories={[]} />);
   return { onAdd, onClose };
 }
 
@@ -52,7 +52,7 @@ describe('AddTaskModal — submission', () => {
     await userEvent.type(screen.getByPlaceholderText(/enter description/i), 'From the store');
     await userEvent.click(screen.getByRole('button', { name: /add task/i }));
 
-    expect(onAdd).toHaveBeenCalledWith({ title: 'Buy milk', description: 'From the store' });
+    expect(onAdd).toHaveBeenCalledWith({ title: 'Buy milk', description: 'From the store', categoryId: null });
   });
 
   it('calls onClose after successful submit', async () => {

--- a/client/src/components/CategoryModal/CategoryModal.module.css
+++ b/client/src/components/CategoryModal/CategoryModal.module.css
@@ -96,13 +96,14 @@
 /* Color picker */
 .colorGrid {
 	display: flex;
+	justify-content: center;
 	flex-wrap: wrap;
 	gap: 8px;
 }
 
 .colorOption {
-	width: 30px;
-	height: 30px;
+	width: 23px;
+	height: 23px;
 	border-radius: 50%;
 	border: 2px solid transparent;
 	cursor: pointer;

--- a/client/src/components/CategoryModal/CategoryModal.module.css
+++ b/client/src/components/CategoryModal/CategoryModal.module.css
@@ -1,0 +1,215 @@
+.overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.65);
+	backdrop-filter: blur(6px);
+	-webkit-backdrop-filter: blur(6px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 999;
+	animation: fadeIn 0.2s ease;
+}
+
+.modal {
+	width: 440px;
+	background: var(--bg-content);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	box-shadow: var(--shadow);
+	animation: scaleIn 0.2s ease;
+	overflow: hidden;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	background: var(--bg-surface);
+	padding: 16px 18px;
+	border-bottom: 1px solid var(--border-color);
+}
+
+.title {
+	color: var(--text-primary);
+	font-weight: 500;
+	font-size: 18px;
+}
+
+.closeBtn {
+	padding: 6px;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+	border-radius: 8px;
+	transition: var(--transition-duration);
+}
+
+.closeBtn:hover {
+	background: var(--bg-content);
+	color: var(--text-primary);
+}
+
+.form {
+	padding: 18px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.inputGroup label {
+	display: block;
+	color: var(--text-secondary);
+	margin-bottom: 8px;
+	font-size: 14px;
+}
+
+.input {
+	width: 100%;
+	padding: 12px;
+	border-radius: 12px;
+	border: 1px solid var(--border-color);
+	background: var(--bg-surface);
+	color: var(--text-primary);
+	outline: none;
+	font-size: 15px;
+	transition: var(--transition-duration);
+}
+
+.input:focus {
+	border-color: var(--color-primary);
+	box-shadow: 0 0 0 2px var(--color-primary-light);
+}
+
+.inputError {
+	border-color: var(--color-red) !important;
+	background: rgba(239, 68, 68, 0.05);
+}
+
+.inputErrorMsg {
+	margin-top: 6px;
+	color: var(--color-red);
+	font-size: 13px;
+}
+
+/* Color picker */
+.colorGrid {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.colorOption {
+	width: 30px;
+	height: 30px;
+	border-radius: 50%;
+	border: 2px solid transparent;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: transform 0.15s ease, box-shadow 0.15s ease;
+	flex-shrink: 0;
+}
+
+.colorOption:hover {
+	transform: scale(1.12);
+}
+
+.colorOption.selected {
+	box-shadow: 0 0 0 3px var(--bg-content), 0 0 0 5px currentColor;
+}
+
+/* Icon picker */
+.iconGrid {
+	display: grid;
+	grid-template-columns: repeat(5, 1fr);
+	gap: 8px;
+}
+
+.iconOption {
+	padding: 9px;
+	border-radius: 10px;
+	border: 1.5px solid var(--border-color);
+	background: var(--bg-surface);
+	color: var(--text-secondary);
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: var(--transition-duration);
+}
+
+.iconOption:hover {
+	background: var(--sidebar-item-hover);
+	color: var(--text-primary);
+}
+
+.iconOption.selected {
+	border-color: var(--color-primary);
+	background: var(--color-primary-light);
+	color: var(--color-primary);
+}
+
+.footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+	margin-top: 4px;
+}
+
+.btn {
+	border: none;
+	font-size: 14px;
+	padding: 10px 16px;
+	border-radius: 12px;
+	cursor: pointer;
+	transition: var(--transition-duration);
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.cancel {
+	background: transparent;
+	color: var(--text-secondary);
+}
+
+.cancel:hover {
+	background: var(--bg-surface);
+}
+
+.save {
+	background: var(--color-primary);
+	color: white;
+}
+
+.save:hover {
+	background: var(--color-primary-hover);
+}
+
+@keyframes fadeIn {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+@keyframes scaleIn {
+	from { transform: scale(0.95); opacity: 0; }
+	to { transform: scale(1); opacity: 1; }
+}
+
+@media (max-width: 480px) {
+	.overlay {
+		align-items: flex-end;
+	}
+
+	.modal {
+		width: min(440px, calc(100% - 24px));
+		margin-bottom: 16px;
+	}
+
+	.iconGrid {
+		grid-template-columns: repeat(5, 1fr);
+	}
+}

--- a/client/src/components/CategoryModal/CategoryModal.tsx
+++ b/client/src/components/CategoryModal/CategoryModal.tsx
@@ -102,7 +102,7 @@ const CategoryModal = ({ category, onSave, onClose }: CategoryModalProps) => {
 
   const validate = (value: string): string => {
     if (!value.trim()) return 'Name is required';
-    if (value.length > 40) return 'Name must be 40 characters or less';
+    if (value.length > 15) return 'Name must be 15 characters or less';
     return '';
   };
 
@@ -120,7 +120,7 @@ const CategoryModal = ({ category, onSave, onClose }: CategoryModalProps) => {
     <div className={styles.overlay} onClick={onClose}>
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <div className={styles.header}>
-          <h3 className={styles.title}>{category ? 'Edit Category' : 'New Category'}</h3>
+          <h3 className={styles.title}>{category ? 'Edit Category' : 'Add New Category'}</h3>
           <button onClick={onClose} className={styles.closeBtn}>
             <X size={20} />
           </button>
@@ -140,7 +140,7 @@ const CategoryModal = ({ category, onSave, onClose }: CategoryModalProps) => {
               className={`${styles.input} ${nameError ? styles.inputError : ''}`}
               placeholder='e.g. Work, Study, Personal...'
               autoFocus
-              maxLength={40}
+              maxLength={15}
             />
             {nameError && <p className={styles.inputErrorMsg}>{nameError}</p>}
           </div>

--- a/client/src/components/CategoryModal/CategoryModal.tsx
+++ b/client/src/components/CategoryModal/CategoryModal.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import {
+  X,
+  Check,
+  Briefcase,
+  Home,
+  Book,
+  Heart,
+  Star,
+  ShoppingCart,
+  Dumbbell,
+  Code,
+  Music,
+  Camera,
+  Plane,
+  Car,
+  Coffee,
+  Gamepad2,
+  Palette,
+  Globe,
+  Leaf,
+  Zap,
+  Target,
+  Users,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { Category, CategoryColor, CategoryIcon } from '../../types';
+import styles from './CategoryModal.module.css';
+
+const ALLOWED_COLORS: CategoryColor[] = [
+  '#ef4444',
+  '#f97316',
+  '#eab308',
+  '#22c55e',
+  '#14b8a6',
+  '#3b82f6',
+  '#8b5cf6',
+  '#ec4899',
+  '#64748b',
+  '#84cc16',
+  '#06b6d4',
+  '#f43f5e',
+];
+
+const ALLOWED_ICONS: CategoryIcon[] = [
+  'Briefcase',
+  'Home',
+  'Book',
+  'Heart',
+  'Star',
+  'ShoppingCart',
+  'Dumbbell',
+  'Code',
+  'Music',
+  'Camera',
+  'Plane',
+  'Car',
+  'Coffee',
+  'Gamepad2',
+  'Palette',
+  'Globe',
+  'Leaf',
+  'Zap',
+  'Target',
+  'Users',
+];
+
+const ICON_MAP: Record<CategoryIcon, LucideIcon> = {
+  Briefcase,
+  Home,
+  Book,
+  Heart,
+  Star,
+  ShoppingCart,
+  Dumbbell,
+  Code,
+  Music,
+  Camera,
+  Plane,
+  Car,
+  Coffee,
+  Gamepad2,
+  Palette,
+  Globe,
+  Leaf,
+  Zap,
+  Target,
+  Users,
+};
+
+interface CategoryModalProps {
+  category?: Category;
+  onSave: (name: string, color: string, icon: string) => void;
+  onClose: () => void;
+}
+
+const CategoryModal = ({ category, onSave, onClose }: CategoryModalProps) => {
+  const [name, setName] = useState(category?.name ?? '');
+  const [selectedColor, setSelectedColor] = useState<string>(category?.color ?? ALLOWED_COLORS[0]);
+  const [selectedIcon, setSelectedIcon] = useState<string>(category?.icon ?? ALLOWED_ICONS[0]);
+  const [nameError, setNameError] = useState('');
+
+  const validate = (value: string): string => {
+    if (!value.trim()) return 'Name is required';
+    if (value.length > 40) return 'Name must be 40 characters or less';
+    return '';
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const error = validate(name);
+    if (error) {
+      setNameError(error);
+      return;
+    }
+    onSave(name.trim(), selectedColor, selectedIcon);
+  };
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h3 className={styles.title}>{category ? 'Edit Category' : 'New Category'}</h3>
+          <button onClick={onClose} className={styles.closeBtn}>
+            <X size={20} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <div className={styles.inputGroup}>
+            <label htmlFor='categoryName'>Name</label>
+            <input
+              id='categoryName'
+              type='text'
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                if (nameError) setNameError(validate(e.target.value));
+              }}
+              className={`${styles.input} ${nameError ? styles.inputError : ''}`}
+              placeholder='e.g. Work, Study, Personal...'
+              autoFocus
+              maxLength={40}
+            />
+            {nameError && <p className={styles.inputErrorMsg}>{nameError}</p>}
+          </div>
+
+          <div className={styles.inputGroup}>
+            <label>Color</label>
+            <div className={styles.colorGrid}>
+              {ALLOWED_COLORS.map((color) => (
+                <button
+                  key={color}
+                  type='button'
+                  className={`${styles.colorOption} ${selectedColor === color ? styles.selected : ''}`}
+                  style={{ backgroundColor: color }}
+                  onClick={() => setSelectedColor(color)}>
+                  {selectedColor === color && <Check size={14} color='white' strokeWidth={3} />}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.inputGroup}>
+            <label>Icon</label>
+            <div className={styles.iconGrid}>
+              {ALLOWED_ICONS.map((iconName) => {
+                const Icon = ICON_MAP[iconName];
+                return (
+                  <button
+                    key={iconName}
+                    type='button'
+                    className={`${styles.iconOption} ${selectedIcon === iconName ? styles.selected : ''}`}
+                    onClick={() => setSelectedIcon(iconName)}
+                    title={iconName}>
+                    <Icon size={18} strokeWidth={1.8} />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className={styles.footer}>
+            <button type='button' onClick={onClose} className={`${styles.btn} ${styles.cancel}`}>
+              Cancel
+            </button>
+            <button type='submit' className={`${styles.btn} ${styles.save}`}>
+              {category ? 'Save changes' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default CategoryModal;

--- a/client/src/components/CompletedTasks/CompletedTasks.tsx
+++ b/client/src/components/CompletedTasks/CompletedTasks.tsx
@@ -99,10 +99,11 @@ const CompletedTasks = ({ categories }: CompletedTasksProps) => {
             </div>
           </div>
         ) : (
-          completedTasks.map((task) => (
+          completedTasks.map((task, index) => (
             <ToDoItem
               key={task.id}
               task={task}
+              index={index}
               onToggle={toggleTask}
               onDelete={deleteTask}
               onEdit={updateTask}

--- a/client/src/components/CompletedTasks/CompletedTasks.tsx
+++ b/client/src/components/CompletedTasks/CompletedTasks.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchTasks, editTask as apiEditTask, deleteTask as apiDeleteTask } from '../../api/taskApi';
-import type { Task } from '../../types';
+import type { Task, Category } from '../../types';
 
 import ToDoItem from '../ToDoItem';
 import DeleteAllButton from '../DeleteAllButton';
@@ -10,7 +10,11 @@ import Loader from '../Loader';
 import { Check } from 'lucide-react';
 import styles from './CompletedTasks.module.css';
 
-const CompletedTasks = () => {
+interface CompletedTasksProps {
+  categories: Category[];
+}
+
+const CompletedTasks = ({ categories }: CompletedTasksProps) => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -106,7 +110,7 @@ const CompletedTasks = () => {
               setActivePomodoroId={() => {}}
               activePomoData={null}
               setActivePomoData={() => {}}
-              categories={[]}
+              categories={categories}
             />
           ))
         )}

--- a/client/src/components/CompletedTasks/CompletedTasks.tsx
+++ b/client/src/components/CompletedTasks/CompletedTasks.tsx
@@ -106,6 +106,7 @@ const CompletedTasks = () => {
               setActivePomodoroId={() => {}}
               activePomoData={null}
               setActivePomoData={() => {}}
+              categories={[]}
             />
           ))
         )}

--- a/client/src/components/EditTaskModal/EditTaskModal.tsx
+++ b/client/src/components/EditTaskModal/EditTaskModal.tsx
@@ -1,17 +1,19 @@
 import { useState } from 'react';
 import { X, Pencil, AlertCircle } from 'lucide-react';
-import type { Task } from '../../types';
+import type { Task, Category } from '../../types';
 import styles from './EditTaskModal.module.css';
 
 interface EditTaskModalProps {
   task: Task;
-  onUpdate: (id: number, updates: { title: string; description: string }) => void;
+  onUpdate: (id: number, updates: { title: string; description: string; categoryId: number | null }) => void;
   onClose: () => void;
+  categories: Category[];
 }
 
-const EditTaskModal = ({ task, onUpdate, onClose }: EditTaskModalProps) => {
+const EditTaskModal = ({ task, onUpdate, onClose, categories }: EditTaskModalProps) => {
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description || '');
+  const [categoryId, setCategoryId] = useState<number | null>(task.categoryId);
   const [inputError, setInputError] = useState('');
 
   const validateTitle = (value: string): string => {
@@ -35,7 +37,7 @@ const EditTaskModal = ({ task, onUpdate, onClose }: EditTaskModalProps) => {
       return;
     }
 
-    onUpdate(task.id, { title, description });
+    onUpdate(task.id, { title, description, categoryId });
     onClose();
   };
 
@@ -85,6 +87,23 @@ const EditTaskModal = ({ task, onUpdate, onClose }: EditTaskModalProps) => {
               placeholder='Enter description...'
             />
           </div>
+
+          {categories.length > 0 && (
+            <div className={styles.inputGroup}>
+              <label>Category (optional)</label>
+              <select
+                className={styles.input}
+                value={categoryId ?? ''}
+                onChange={(e) => setCategoryId(e.target.value ? Number(e.target.value) : null)}>
+                <option value=''>No category</option>
+                {categories.map((cat) => (
+                  <option key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           <div className={styles.footer}>
             <button type='button' onClick={onClose} className={`${styles.btn} ${styles.cancel}`}>

--- a/client/src/components/Sidebar/CategoryItem.tsx
+++ b/client/src/components/Sidebar/CategoryItem.tsx
@@ -1,0 +1,95 @@
+import {
+  Briefcase,
+  Home,
+  Book,
+  Heart,
+  Star,
+  ShoppingCart,
+  Dumbbell,
+  Code,
+  Music,
+  Camera,
+  Plane,
+  Car,
+  Coffee,
+  Gamepad2,
+  Palette,
+  Globe,
+  Leaf,
+  Zap,
+  Target,
+  Users,
+  Pencil,
+  Trash2,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { Category, CategoryIcon } from '../../types';
+import styles from './Sidebar.module.css';
+
+const ICON_MAP: Record<CategoryIcon, LucideIcon> = {
+  Briefcase,
+  Home,
+  Book,
+  Heart,
+  Star,
+  ShoppingCart,
+  Dumbbell,
+  Code,
+  Music,
+  Camera,
+  Plane,
+  Car,
+  Coffee,
+  Gamepad2,
+  Palette,
+  Globe,
+  Leaf,
+  Zap,
+  Target,
+  Users,
+};
+
+interface CategoryItemProps {
+  category: Category;
+  isSelected: boolean;
+  onSelect: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const CategoryItem = ({ category, isSelected, onSelect, onEdit, onDelete }: CategoryItemProps) => {
+  const Icon = ICON_MAP[category.icon as CategoryIcon] ?? Briefcase;
+
+  return (
+    <button
+      className={`${styles.categoryItem} ${isSelected ? styles.categoryActive : ''}`}
+      onClick={onSelect}>
+      <span className={styles.categoryIcon} style={{ backgroundColor: category.color }}>
+        <Icon size={14} strokeWidth={2} />
+      </span>
+      <span className={styles.categoryName}>{category.name}</span>
+      <span className={styles.categoryActions}>
+        <button
+          className={styles.categoryActionBtn}
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit();
+          }}
+          title='Edit'>
+          <Pencil size={13} />
+        </button>
+        <button
+          className={`${styles.categoryActionBtn} ${styles.categoryDeleteBtn}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          title='Delete'>
+          <Trash2 size={13} />
+        </button>
+      </span>
+    </button>
+  );
+};
+
+export default CategoryItem;

--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -10,7 +10,144 @@
 	display: flex;
 	flex-direction: column;
 	gap: 14px;
+}
+
+/* ── Categories section ───────────────────────── */
+.categoriesSection {
+	margin-top: 20px;
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
 	flex: 1;
+}
+
+.categoriesHeader {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0 8px;
+	margin-bottom: 4px;
+}
+
+.categoriesLabel {
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.06em;
+	color: var(--text-muted);
+	font-weight: 600;
+}
+
+.addCategoryBtn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	border-radius: 6px;
+	cursor: pointer;
+	transition: var(--transition);
+}
+
+.addCategoryBtn:hover {
+	background: var(--sidebar-item-hover);
+	color: var(--text-primary);
+}
+
+.categoryItem {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 7px 8px;
+	border-radius: 12px;
+	border: none;
+	cursor: pointer;
+	width: 100%;
+	background: transparent;
+	color: var(--sidebar-item-text);
+	font-size: 14px;
+	text-align: left;
+	transition: background var(--transition), color var(--transition);
+	position: relative;
+}
+
+.categoryItem:hover {
+	background: var(--sidebar-item-hover);
+}
+
+.categoryActive {
+	background: var(--color-primary) !important;
+	color: var(--sidebar-item-active-text, white);
+}
+
+.categoryIcon {
+	width: 24px;
+	height: 24px;
+	border-radius: 7px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	color: white;
+}
+
+.categoryAllDot {
+	width: 24px;
+	height: 24px;
+	border-radius: 7px;
+	background: var(--sidebar-item-hover);
+	flex-shrink: 0;
+}
+
+.categoryActive .categoryAllDot {
+	background: rgba(255, 255, 255, 0.25);
+}
+
+.categoryName {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.categoryActions {
+	display: none;
+	align-items: center;
+	gap: 2px;
+	margin-left: auto;
+	flex-shrink: 0;
+}
+
+.categoryItem:hover .categoryActions,
+.categoryActive .categoryActions {
+	display: flex;
+}
+
+.categoryActionBtn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	border: none;
+	background: transparent;
+	color: inherit;
+	opacity: 0.7;
+	border-radius: 6px;
+	cursor: pointer;
+	transition: var(--transition);
+}
+
+.categoryActionBtn:hover {
+	opacity: 1;
+	background: rgba(0, 0, 0, 0.1);
+}
+
+.categoryDeleteBtn:hover {
+	color: var(--color-red, #ef4444);
+	background: rgba(239, 68, 68, 0.12);
 }
 
 .sidebarItem {

--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -18,6 +18,8 @@
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
+	overflow-y: auto;
+	min-height: 0;
 }
 
 .categoriesHeader {

--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -13,21 +13,23 @@
 }
 
 /* ── Categories section ───────────────────────── */
-.categoriesSection {
-	margin-top: 20px;
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-	overflow-y: auto;
-	min-height: 0;
-}
-
 .categoriesHeader {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 	padding: 0 8px;
+	margin-top: 20px;
 	margin-bottom: 4px;
+	flex-shrink: 0;
+}
+
+.categoriesSection {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	overflow-y: auto;
+	min-height: 0;
+	padding-right: 4px;
 }
 
 .categoriesLabel {

--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -18,7 +18,6 @@
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
-	flex: 1;
 }
 
 .categoriesHeader {
@@ -180,8 +179,21 @@
 	box-shadow: var(--shadow-active);
 }
 
+.divider {
+	border: none;
+	border-top: 1px solid var(--border-color);
+	margin: 16px 0 12px;
+}
+
+.bottomActions {
+	margin-top: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+}
+
 .logout {
-	margin-top: 24px;
+	margin-top: 10px;
 	padding: 10px 12px;
 	border-radius: 14px;
 	border: none;

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -62,20 +62,20 @@ const Sidebar = ({
 					</button>
 				</nav>
 
-				<div className={styles.categoriesSection}>
-					<div className={styles.categoriesHeader}>
-						<span className={styles.categoriesLabel}>Categories</span>
-						<button
-							className={styles.addCategoryBtn}
-							onClick={() => {
-                onClose();
-								onCategoryCreate();
-							}}
-							title='New category'>
-							<Plus size={15} />
-						</button>
-					</div>
+				<div className={styles.categoriesHeader}>
+					<span className={styles.categoriesLabel}>Categories</span>
+					<button
+						className={styles.addCategoryBtn}
+						onClick={() => {
+							onClose();
+							onCategoryCreate();
+						}}
+						title='New category'>
+						<Plus size={15} />
+					</button>
+				</div>
 
+				<div className={styles.categoriesSection}>
 					<button
 						className={`${styles.categoryItem} ${selectedCategoryId === null && activeTab === 'active' ? styles.categoryActive : ''}`}
 						onClick={() => {
@@ -84,7 +84,7 @@ const Sidebar = ({
 							onClose();
 						}}>
 						<span className={styles.categoryAllDot} />
-						<span className={styles.categoryName}>All tasks</span>
+						<span className={styles.categoryName}>All Tasks</span>
 					</button>
 
 					{categories.map((cat) => (

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { logout } from '../../api/auth';
 import { ListTodo, CheckCircle2, X, Settings as SettingsIcon, LogOut, Plus } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
 import type { Category } from '../../types';
 import CategoryItem from './CategoryItem';
 import styles from './Sidebar.module.css';
@@ -19,12 +18,6 @@ interface SidebarProps {
 	onCategoryDelete: (id: number) => void;
 }
 
-interface Tab {
-	id: string;
-	label: string;
-	icon: LucideIcon;
-}
-
 const Sidebar = ({
 	activeTab,
 	onTabChange,
@@ -37,12 +30,6 @@ const Sidebar = ({
 	onCategoryUpdate,
 	onCategoryDelete,
 }: SidebarProps) => {
-	const tabs: Tab[] = [
-		{ id: 'active', label: 'Active Tasks', icon: ListTodo },
-		{ id: 'completed', label: 'Completed Tasks', icon: CheckCircle2 },
-		{ id: 'settings', label: 'Settings', icon: SettingsIcon },
-	];
-
 	const navigate = useNavigate();
 
 	const handleLogout = async () => {
@@ -63,23 +50,16 @@ const Sidebar = ({
 				</button>
 
 				<nav className={styles.nav}>
-					{tabs.map((tab) => {
-						const Icon = tab.icon;
-
-						return (
-							<button
-								key={tab.id}
-								className={`${styles.sidebarItem} ${activeTab === tab.id && selectedCategoryId === null ? styles.active : ''}`}
-								onClick={() => {
-									onTabChange(tab.id);
-									onCategorySelect(null);
-									onClose();
-								}}>
-								<Icon size={18} strokeWidth={2} />
-								{tab.label}
-							</button>
-						);
-					})}
+					<button
+						className={`${styles.sidebarItem} ${activeTab === 'active' && selectedCategoryId === null ? styles.active : ''}`}
+						onClick={() => {
+							onTabChange('active');
+							onCategorySelect(null);
+							onClose();
+						}}>
+						<ListTodo size={18} strokeWidth={2} />
+						Active Tasks
+					</button>
 				</nav>
 
 				<div className={styles.categoriesSection}>
@@ -123,10 +103,36 @@ const Sidebar = ({
 					))}
 				</div>
 
-				<button className={styles.logout} onClick={handleLogout}>
-					<LogOut size={18} strokeWidth={2} />
-					Log Out
+				<hr className={styles.divider} />
+
+				<button
+					className={`${styles.sidebarItem} ${activeTab === 'completed' && selectedCategoryId === null ? styles.active : ''}`}
+					onClick={() => {
+						onTabChange('completed');
+						onCategorySelect(null);
+						onClose();
+					}}>
+					<CheckCircle2 size={18} strokeWidth={2} />
+					Completed Tasks
 				</button>
+
+				<div className={styles.bottomActions}>
+					<button
+						className={`${styles.sidebarItem} ${activeTab === 'settings' && selectedCategoryId === null ? styles.active : ''}`}
+						onClick={() => {
+							onTabChange('settings');
+							onCategorySelect(null);
+							onClose();
+						}}>
+						<SettingsIcon size={18} strokeWidth={2} />
+						Settings
+					</button>
+
+					<button className={styles.logout} onClick={handleLogout}>
+						<LogOut size={18} strokeWidth={2} />
+						Log Out
+					</button>
+				</div>
 			</aside>
 		</>
 	);

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -51,7 +51,7 @@ const Sidebar = ({
 
 				<nav className={styles.nav}>
 					<button
-						className={`${styles.sidebarItem} ${activeTab === 'active' && selectedCategoryId === null ? styles.active : ''}`}
+						className={`${styles.sidebarItem} ${activeTab === 'active' ? styles.active : ''}`}
 						onClick={() => {
 							onTabChange('active');
 							onCategorySelect(null);

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -1,74 +1,135 @@
 import { useNavigate } from 'react-router-dom';
 import { logout } from '../../api/auth';
-import { ListTodo, CheckCircle2, X, Settings as SettingsIcon, LogOut } from 'lucide-react';
+import { ListTodo, CheckCircle2, X, Settings as SettingsIcon, LogOut, Plus } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import type { Category } from '../../types';
+import CategoryItem from './CategoryItem';
 import styles from './Sidebar.module.css';
 
 interface SidebarProps {
-  activeTab: string;
-  onTabChange: (tab: string) => void;
-  isOpen: boolean;
-  onClose: () => void;
+	activeTab: string;
+	onTabChange: (tab: string) => void;
+	isOpen: boolean;
+	onClose: () => void;
+	categories: Category[];
+	selectedCategoryId: number | null;
+	onCategorySelect: (id: number | null) => void;
+	onCategoryCreate: () => void;
+	onCategoryUpdate: (category: Category) => void;
+	onCategoryDelete: (id: number) => void;
 }
 
 interface Tab {
-  id: string;
-  label: string;
-  icon: LucideIcon;
+	id: string;
+	label: string;
+	icon: LucideIcon;
 }
 
-const Sidebar = ({ activeTab, onTabChange, isOpen, onClose }: SidebarProps) => {
-  const tabs: Tab[] = [
-    { id: 'active', label: 'Active Tasks', icon: ListTodo },
-    { id: 'completed', label: 'Completed Tasks', icon: CheckCircle2 },
-    { id: 'settings', label: 'Settings', icon: SettingsIcon },
-  ];
+const Sidebar = ({
+	activeTab,
+	onTabChange,
+	isOpen,
+	onClose,
+	categories,
+	selectedCategoryId,
+	onCategorySelect,
+	onCategoryCreate,
+	onCategoryUpdate,
+	onCategoryDelete,
+}: SidebarProps) => {
+	const tabs: Tab[] = [
+		{ id: 'active', label: 'Active Tasks', icon: ListTodo },
+		{ id: 'completed', label: 'Completed Tasks', icon: CheckCircle2 },
+		{ id: 'settings', label: 'Settings', icon: SettingsIcon },
+	];
 
-  const navigate = useNavigate();
+	const navigate = useNavigate();
 
-  const handleLogout = async () => {
-    try {
-      await logout();
-    } finally {
-      navigate('/login');
-    }
-  };
+	const handleLogout = async () => {
+		try {
+			await logout();
+		} finally {
+			navigate('/login');
+		}
+	};
 
-  return (
-    <>
-      {isOpen && <div className={styles.overlay} onClick={onClose} />}
+	return (
+		<>
+			{isOpen && <div className={styles.overlay} onClick={onClose} />}
 
-      <aside className={`${styles.sidebar} ${isOpen ? styles.open : ''}`}>
-        <button className={styles.closeBtn} onClick={onClose}>
-          <X size={32} />
-        </button>
+			<aside className={`${styles.sidebar} ${isOpen ? styles.open : ''}`}>
+				<button className={styles.closeBtn} onClick={onClose}>
+					<X size={32} />
+				</button>
 
-        <nav className={styles.nav}>
-          {tabs.map((tab) => {
-            const Icon = tab.icon;
+				<nav className={styles.nav}>
+					{tabs.map((tab) => {
+						const Icon = tab.icon;
 
-            return (
-              <button
-                key={tab.id}
-                className={`${styles.sidebarItem} ${activeTab === tab.id ? styles.active : ''}`}
-                onClick={() => {
-                  onTabChange(tab.id);
-                  onClose();
-                }}>
-                <Icon size={18} strokeWidth={2} />
-                {tab.label}
-              </button>
-            );
-          })}
-        </nav>
+						return (
+							<button
+								key={tab.id}
+								className={`${styles.sidebarItem} ${activeTab === tab.id && selectedCategoryId === null ? styles.active : ''}`}
+								onClick={() => {
+									onTabChange(tab.id);
+									onCategorySelect(null);
+									onClose();
+								}}>
+								<Icon size={18} strokeWidth={2} />
+								{tab.label}
+							</button>
+						);
+					})}
+				</nav>
 
-        <button className={styles.logout} onClick={handleLogout}>
-          <LogOut size={18} strokeWidth={2} />
-          Log Out
-        </button>
-      </aside>
-    </>
-  );
+				<div className={styles.categoriesSection}>
+					<div className={styles.categoriesHeader}>
+						<span className={styles.categoriesLabel}>Categories</span>
+						<button
+							className={styles.addCategoryBtn}
+							onClick={() => {
+                onClose();
+								onCategoryCreate();
+							}}
+							title='New category'>
+							<Plus size={15} />
+						</button>
+					</div>
+
+					<button
+						className={`${styles.categoryItem} ${selectedCategoryId === null && activeTab === 'active' ? styles.categoryActive : ''}`}
+						onClick={() => {
+							onCategorySelect(null);
+							onTabChange('active');
+							onClose();
+						}}>
+						<span className={styles.categoryAllDot} />
+						<span className={styles.categoryName}>All tasks</span>
+					</button>
+
+					{categories.map((cat) => (
+						<CategoryItem
+							key={cat.id}
+							category={cat}
+							isSelected={selectedCategoryId === cat.id}
+							onSelect={() => {
+								onCategorySelect(cat.id);
+								onTabChange('active');
+								onClose();
+							}}
+							onEdit={() => onCategoryUpdate(cat)}
+							onDelete={() => onCategoryDelete(cat.id)}
+						/>
+					))}
+				</div>
+
+				<button className={styles.logout} onClick={handleLogout}>
+					<LogOut size={18} strokeWidth={2} />
+					Log Out
+				</button>
+			</aside>
+		</>
+	);
 };
 
 export default Sidebar;

--- a/client/src/components/ToDoItem/ToDoItem.module.css
+++ b/client/src/components/ToDoItem/ToDoItem.module.css
@@ -70,6 +70,13 @@
 	transform: scale(1.1);
 }
 
+.todoCheckbox:not(.checked):hover::after {
+	content: '✓';
+	font-size: 14px;
+	color: white;
+	line-height: 1;
+}
+
 .todoCheckbox.checked {
 	background: var(--color-green);
 	border-color: var(--color-green);
@@ -85,20 +92,38 @@
 	color: var(--color-text-primary);
 }
 
+.categoryChip {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	min-width: 24px;
+	border-radius: 25%;
+	flex-shrink: 0;
+}
+
+
 .todoText {
 	display: flex;
 	align-items: center;
 	gap: 6px;
 
-	word-break: break-word;
-	overflow-wrap: anywhere;
 	font-size: 16px;
 	font-weight: 600;
 
 	min-width: 0;
-	max-width: 100%;
+	flex: 1;
+	overflow: hidden;
 
 	color: var(--color-dark-1);
+}
+
+.titleText {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	min-width: 0;
 }
 
 

--- a/client/src/components/ToDoItem/ToDoItem.module.css
+++ b/client/src/components/ToDoItem/ToDoItem.module.css
@@ -26,41 +26,20 @@
 
 	-webkit-tap-highlight-color: transparent;
 	outline: none;
+	cursor: grab;
 }
 
 .todoItem:active {
+	cursor: grabbing;
 	background-color: var(--bg-todo-item);
 	transform: translateY(0);
 }
 
 .dragging {
-	opacity: 0.45;
-	box-shadow: var(--shadow-active, 0 8px 24px rgba(0,0,0,0.15));
-	z-index: 10;
+	opacity: 0 !important;
+	pointer-events: none;
 }
 
-.dragHandle {
-	display: none;
-	align-items: center;
-	justify-content: center;
-	width: 20px;
-	flex-shrink: 0;
-	border: none;
-	background: transparent;
-	color: var(--text-muted);
-	cursor: grab;
-	padding: 0;
-	border-radius: 4px;
-	touch-action: none;
-}
-
-.todoItem:hover .dragHandle {
-	display: flex;
-}
-
-.dragHandle:active {
-	cursor: grabbing;
-}
 
 .clickable {
 	cursor: pointer;
@@ -127,7 +106,7 @@
 .categoryBgIcon {
 	position: absolute;
 	right: 10px;
-	bottom: 5px;
+	top: 5px;
 	width: 35px;
 	height: 35px;
 	display: flex;

--- a/client/src/components/ToDoItem/ToDoItem.module.css
+++ b/client/src/components/ToDoItem/ToDoItem.module.css
@@ -29,6 +29,10 @@
 	cursor: grab;
 }
 
+.notDraggable {
+	cursor: default;
+}
+
 .todoItem:active {
 	cursor: grabbing;
 	background-color: var(--bg-todo-item);

--- a/client/src/components/ToDoItem/ToDoItem.module.css
+++ b/client/src/components/ToDoItem/ToDoItem.module.css
@@ -4,7 +4,10 @@
 	width: 100%;
 	flex-shrink: 0;
 
-	background: var(--bg-todo-item);
+	position: relative;
+	overflow: hidden;
+
+	background-color: var(--bg-todo-item);
 	border: 1px solid var(--border-color);
 	border-radius: var(--border-radius);
 
@@ -26,7 +29,7 @@
 }
 
 .todoItem:active {
-	background: var(--bg-todo-item);
+	background-color: var(--bg-todo-item);
 	transform: translateY(0);
 }
 
@@ -121,15 +124,21 @@
 	color: var(--color-text-primary);
 }
 
-.categoryChip {
-	display: inline-flex;
+.categoryBgIcon {
+	position: absolute;
+	right: 10px;
+	bottom: 5px;
+	width: 35px;
+	height: 35px;
+	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 24px;
-	height: 24px;
-	min-width: 24px;
-	border-radius: 25%;
-	flex-shrink: 0;
+	opacity: 0.2;
+	pointer-events: none;
+}
+
+.hasCategory {
+	padding-right: 50px;
 }
 
 
@@ -488,10 +497,24 @@
 	color: var(--color-red);
 }
 
+.mobileRight {
+	display: none;
+	align-items: center;
+	gap: 4px;
+	margin-left: auto;
+	flex-shrink: 0;
+}
+
+.categoryMobileIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	opacity: 0.5;
+}
+
 .mobilePlus {
 	color: var(--color-text-primary);
-	display: none;
-	margin-left: auto;
+	display: flex;
 
 	align-items: center;
 	justify-content: center;
@@ -522,8 +545,16 @@
 		display: none;
 	}
 
-	.mobilePlus {
+	.mobileRight {
 		display: flex;
+	}
+
+	.categoryBgIcon {
+		display: none;
+	}
+
+	.hasCategory {
+		padding-right: 10px;
 	}
 }
 
@@ -533,9 +564,6 @@
 		pointer-events: auto;
 	}
 
-	.mobilePlus {
-		display: none;
-	}
 }
 
 @keyframes fadeIn {

--- a/client/src/components/ToDoItem/ToDoItem.module.css
+++ b/client/src/components/ToDoItem/ToDoItem.module.css
@@ -30,6 +30,35 @@
 	transform: translateY(0);
 }
 
+.dragging {
+	opacity: 0.45;
+	box-shadow: var(--shadow-active, 0 8px 24px rgba(0,0,0,0.15));
+	z-index: 10;
+}
+
+.dragHandle {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	width: 20px;
+	flex-shrink: 0;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: grab;
+	padding: 0;
+	border-radius: 4px;
+	touch-action: none;
+}
+
+.todoItem:hover .dragHandle {
+	display: flex;
+}
+
+.dragHandle:active {
+	cursor: grabbing;
+}
+
 .clickable {
 	cursor: pointer;
 }

--- a/client/src/components/ToDoItem/ToDoItem.tsx
+++ b/client/src/components/ToDoItem/ToDoItem.tsx
@@ -4,7 +4,7 @@ import { DayPicker } from 'react-day-picker';
 import PomodoroTimer from '../PomodoroTimer';
 import { startPomodoro, getPomodoro } from '../../api/taskApi';
 import { useAuth } from '../../context/AuthContext';
-import type { Task, PomoData } from '../../types';
+import type { Task, PomoData, Category } from '../../types';
 
 import { Pencil, Trash2, CirclePlus, Calendar, AlarmClock, X, ChevronDown } from 'lucide-react';
 import styles from './ToDoItem.module.css';
@@ -19,6 +19,7 @@ interface ToDoItemProps {
   setActivePomodoroId: (id: number | null) => void;
   activePomoData: PomoData | null;
   setActivePomoData: (data: PomoData | null) => void;
+  categories: Category[];
 }
 
 const ToDoItem = ({
@@ -30,6 +31,7 @@ const ToDoItem = ({
   setActivePomodoroId,
   activePomoData,
   setActivePomoData,
+  categories,
 }: ToDoItemProps) => {
   const { user } = useAuth();
 
@@ -197,6 +199,7 @@ const ToDoItem = ({
           task={task}
           onUpdate={(id, updates) => onEdit(id, updates)}
           onClose={() => setShowEditModal(false)}
+          categories={categories}
         />
       )}
 

--- a/client/src/components/ToDoItem/ToDoItem.tsx
+++ b/client/src/components/ToDoItem/ToDoItem.tsx
@@ -6,9 +6,22 @@ import { startPomodoro, getPomodoro } from '../../api/taskApi';
 import { useAuth } from '../../context/AuthContext';
 import type { Task, PomoData, Category } from '../../types';
 
-import { Pencil, Trash2, CirclePlus, Calendar, AlarmClock, X, ChevronDown } from 'lucide-react';
+import {
+  Pencil, Trash2, CirclePlus, Calendar, AlarmClock, X, ChevronDown,
+  Briefcase, Home, Book, Heart, Star, ShoppingCart, Dumbbell, Code,
+  Music, Camera, Plane, Car, Coffee, Gamepad2, Palette, Globe, Leaf,
+  Zap, Target, Users,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { CategoryIcon } from '../../types';
 import styles from './ToDoItem.module.css';
 import 'react-day-picker/dist/style.css';
+
+const ICON_MAP: Record<CategoryIcon, LucideIcon> = {
+  Briefcase, Home, Book, Heart, Star, ShoppingCart, Dumbbell, Code,
+  Music, Camera, Plane, Car, Coffee, Gamepad2, Palette, Globe, Leaf,
+  Zap, Target, Users,
+};
 
 interface ToDoItemProps {
   task: Task;
@@ -42,6 +55,7 @@ const ToDoItem = ({
   const [dueDate, setDueDate] = useState<Date | null>(null);
 
   const effectiveDueDate = dueDate ?? (task.scheduled ? new Date(task.scheduled) : null);
+  const resolvedCategory = task.category ?? categories.find((c) => c.id === task.categoryId) ?? null;
 
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
@@ -94,8 +108,20 @@ const ToDoItem = ({
             {task.done && <span className={styles.checkmark}>✓</span>}
           </div>
 
+          {resolvedCategory && (() => {
+            const Icon = ICON_MAP[resolvedCategory.icon as CategoryIcon] ?? Briefcase;
+            return (
+              <span
+                className={styles.categoryChip}
+                style={{ backgroundColor: resolvedCategory.color }}
+                title={resolvedCategory.name}>
+                <Icon size={13} strokeWidth={2} color='white' />
+              </span>
+            );
+          })()}
+
           <p className={`${styles['todoText']} ${task.done ? styles.done : ''}`}>
-            {task.title}
+            <span className={styles.titleText}>{task.title}</span>
 
             {task.description && (
               <ChevronDown

--- a/client/src/components/ToDoItem/ToDoItem.tsx
+++ b/client/src/components/ToDoItem/ToDoItem.tsx
@@ -5,8 +5,7 @@ import PomodoroTimer from '../PomodoroTimer';
 import { startPomodoro, getPomodoro } from '../../api/taskApi';
 import { useAuth } from '../../context/AuthContext';
 import type { Task, PomoData, Category } from '../../types';
-import { useSortable } from '@dnd-kit/sortable';
-import { CSS } from '@dnd-kit/utilities';
+import { useSortable } from '@dnd-kit/react/sortable';
 
 import {
   Pencil, Trash2, CirclePlus, Calendar, AlarmClock, X, ChevronDown,
@@ -27,6 +26,8 @@ const ICON_MAP: Record<CategoryIcon, LucideIcon> = {
 
 interface ToDoItemProps {
   task: Task;
+  index: number;
+  draggable?: boolean;
   onToggle: (id: number) => void;
   onDelete: (id: number) => void;
   onEdit: (id: number, updates: Record<string, unknown>) => void;
@@ -39,6 +40,8 @@ interface ToDoItemProps {
 
 const ToDoItem = ({
   task,
+  index,
+  draggable = false,
   onToggle,
   onDelete,
   onEdit,
@@ -49,8 +52,7 @@ const ToDoItem = ({
   categories,
 }: ToDoItemProps) => {
   const { user } = useAuth();
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: task.id });
-  const dragStyle = { transform: CSS.Transform.toString(transform), transition };
+  const { ref, isDragSource } = useSortable({ id: task.id, index, disabled: !draggable });
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [showMobileActions, setShowMobileActions] = useState(false);
@@ -104,11 +106,9 @@ const ToDoItem = ({
   return (
     <>
       <div
-        ref={setNodeRef}
-        style={{ ...dragStyle, backgroundImage: categoryGradient }}
-        className={`${styles['todoItem']} ${resolvedCategory ? styles.hasCategory : ''} ${isExpanded ? styles.expanded : ''} ${task.description ? styles.clickable : ''} ${isDragging ? styles.dragging : ''}`}
-        {...attributes}
-        {...listeners}
+        ref={ref}
+        style={{ backgroundImage: categoryGradient }}
+        className={`${styles['todoItem']} ${resolvedCategory ? styles.hasCategory : ''} ${isExpanded ? styles.expanded : ''} ${task.description ? styles.clickable : ''} ${isDragSource ? styles.dragging : ''} ${!draggable ? styles.notDraggable : ''}`}
         onClick={() => {
           if (!task.description) return;
           setIsExpanded((prev) => !prev);

--- a/client/src/components/ToDoItem/ToDoItem.tsx
+++ b/client/src/components/ToDoItem/ToDoItem.tsx
@@ -5,9 +5,11 @@ import PomodoroTimer from '../PomodoroTimer';
 import { startPomodoro, getPomodoro } from '../../api/taskApi';
 import { useAuth } from '../../context/AuthContext';
 import type { Task, PomoData, Category } from '../../types';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 import {
-  Pencil, Trash2, CirclePlus, Calendar, AlarmClock, X, ChevronDown,
+  Pencil, Trash2, CirclePlus, Calendar, AlarmClock, X, ChevronDown, GripVertical,
   Briefcase, Home, Book, Heart, Star, ShoppingCart, Dumbbell, Code,
   Music, Camera, Plane, Car, Coffee, Gamepad2, Palette, Globe, Leaf,
   Zap, Target, Users,
@@ -47,6 +49,8 @@ const ToDoItem = ({
   categories,
 }: ToDoItemProps) => {
   const { user } = useAuth();
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: task.id });
+  const dragStyle = { transform: CSS.Transform.toString(transform), transition };
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [showMobileActions, setShowMobileActions] = useState(false);
@@ -90,12 +94,18 @@ const ToDoItem = ({
   return (
     <>
       <div
-        className={`${styles['todoItem']} ${isExpanded ? styles.expanded : ''} ${task.description ? styles.clickable : ''}`}
+        ref={setNodeRef}
+        style={dragStyle}
+        className={`${styles['todoItem']} ${isExpanded ? styles.expanded : ''} ${task.description ? styles.clickable : ''} ${isDragging ? styles.dragging : ''}`}
+        {...attributes}
         onClick={() => {
           if (!task.description) return;
           setIsExpanded((prev) => !prev);
         }}>
         <div className={styles['todoMainRow']}>
+          <button className={styles.dragHandle} {...listeners} tabIndex={-1} onClick={(e) => e.stopPropagation()}>
+            <GripVertical size={16} />
+          </button>
           <div
             className={`${styles['todoCheckbox']} ${task.done ? styles.checked : ''}`}
             onClick={(e) => {

--- a/client/src/components/ToDoItem/ToDoItem.tsx
+++ b/client/src/components/ToDoItem/ToDoItem.tsx
@@ -59,7 +59,17 @@ const ToDoItem = ({
   const [dueDate, setDueDate] = useState<Date | null>(null);
 
   const effectiveDueDate = dueDate ?? (task.scheduled ? new Date(task.scheduled) : null);
-  const resolvedCategory = task.category ?? categories.find((c) => c.id === task.categoryId) ?? null;
+  const resolvedCategory = categories.find((c) => c.id === task.categoryId) ?? task.category ?? null;
+
+  const categoryGradient = resolvedCategory
+    ? (() => {
+        const hex = resolvedCategory.color.replace('#', '');
+        const r = parseInt(hex.slice(0, 2), 16);
+        const g = parseInt(hex.slice(2, 4), 16);
+        const b = parseInt(hex.slice(4, 6), 16);
+        return `linear-gradient(to left, rgba(${r},${g},${b},0.3) 0%, transparent 65%)`;
+      })()
+    : undefined;
 
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
@@ -95,13 +105,22 @@ const ToDoItem = ({
     <>
       <div
         ref={setNodeRef}
-        style={dragStyle}
-        className={`${styles['todoItem']} ${isExpanded ? styles.expanded : ''} ${task.description ? styles.clickable : ''} ${isDragging ? styles.dragging : ''}`}
+        style={{ ...dragStyle, backgroundImage: categoryGradient }}
+        className={`${styles['todoItem']} ${resolvedCategory ? styles.hasCategory : ''} ${isExpanded ? styles.expanded : ''} ${task.description ? styles.clickable : ''} ${isDragging ? styles.dragging : ''}`}
         {...attributes}
         onClick={() => {
           if (!task.description) return;
           setIsExpanded((prev) => !prev);
         }}>
+        {resolvedCategory && (() => {
+          const Icon = ICON_MAP[resolvedCategory.icon as CategoryIcon] ?? Briefcase;
+          return (
+            <span className={styles.categoryBgIcon} style={{ color: resolvedCategory.color }} aria-hidden>
+              <Icon size={35} strokeWidth={1.5} />
+            </span>
+          );
+        })()}
+
         <div className={styles['todoMainRow']}>
           <button className={styles.dragHandle} {...listeners} tabIndex={-1} onClick={(e) => e.stopPropagation()}>
             <GripVertical size={16} />
@@ -118,17 +137,6 @@ const ToDoItem = ({
             {task.done && <span className={styles.checkmark}>✓</span>}
           </div>
 
-          {resolvedCategory && (() => {
-            const Icon = ICON_MAP[resolvedCategory.icon as CategoryIcon] ?? Briefcase;
-            return (
-              <span
-                className={styles.categoryChip}
-                style={{ backgroundColor: resolvedCategory.color }}
-                title={resolvedCategory.name}>
-                <Icon size={13} strokeWidth={2} color='white' />
-              </span>
-            );
-          })()}
 
           <p className={`${styles['todoText']} ${task.done ? styles.done : ''}`}>
             <span className={styles.titleText}>{task.title}</span>
@@ -202,25 +210,36 @@ const ToDoItem = ({
             </button>
           </div>
 
-          {!task.done ? (
-            <button
-              className={styles.mobilePlus}
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowMobileActions(true);
-              }}>
-              <CirclePlus size={20} />
-            </button>
-          ) : (
-            <button
-              className={styles.mobilePlus}
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(task.id);
-              }}>
-              <Trash2 size={20} />
-            </button>
-          )}
+          <div className={styles.mobileRight}>
+            {resolvedCategory && (() => {
+              const Icon = ICON_MAP[resolvedCategory.icon as CategoryIcon] ?? Briefcase;
+              return (
+                <span className={styles.categoryMobileIcon} aria-hidden>
+                  <Icon size={20} strokeWidth={1.5} color={resolvedCategory.color} />
+                </span>
+              );
+            })()}
+
+            {!task.done ? (
+              <button
+                className={styles.mobilePlus}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowMobileActions(true);
+                }}>
+                <CirclePlus size={20} />
+              </button>
+            ) : (
+              <button
+                className={styles.mobilePlus}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete(task.id);
+                }}>
+                <Trash2 size={20} />
+              </button>
+            )}
+          </div>
         </div>
 
         <div className={`${styles['descriptionWrapper']} ${isExpanded ? styles.open : ''}`}>

--- a/client/src/components/ToDoItem/ToDoItem.tsx
+++ b/client/src/components/ToDoItem/ToDoItem.tsx
@@ -9,7 +9,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
 import {
-  Pencil, Trash2, CirclePlus, Calendar, AlarmClock, X, ChevronDown, GripVertical,
+  Pencil, Trash2, CirclePlus, Calendar, AlarmClock, X, ChevronDown,
   Briefcase, Home, Book, Heart, Star, ShoppingCart, Dumbbell, Code,
   Music, Camera, Plane, Car, Coffee, Gamepad2, Palette, Globe, Leaf,
   Zap, Target, Users,
@@ -108,6 +108,7 @@ const ToDoItem = ({
         style={{ ...dragStyle, backgroundImage: categoryGradient }}
         className={`${styles['todoItem']} ${resolvedCategory ? styles.hasCategory : ''} ${isExpanded ? styles.expanded : ''} ${task.description ? styles.clickable : ''} ${isDragging ? styles.dragging : ''}`}
         {...attributes}
+        {...listeners}
         onClick={() => {
           if (!task.description) return;
           setIsExpanded((prev) => !prev);
@@ -122,11 +123,9 @@ const ToDoItem = ({
         })()}
 
         <div className={styles['todoMainRow']}>
-          <button className={styles.dragHandle} {...listeners} tabIndex={-1} onClick={(e) => e.stopPropagation()}>
-            <GripVertical size={16} />
-          </button>
           <div
             className={`${styles['todoCheckbox']} ${task.done ? styles.checked : ''}`}
+            onPointerDown={(e) => e.stopPropagation()}
             onClick={(e) => {
               e.stopPropagation();
               if (activePomodoroId === task.id) {
@@ -161,6 +160,7 @@ const ToDoItem = ({
             {effectiveDueDate && (
               <div
                 className={`${styles['todoDate']} ${isToday ? styles['todoDate--today'] : ''} ${isPast ? styles['todoDate--past'] : ''} ${styles['todoDate--clickable']}`}
+                onPointerDown={(e) => e.stopPropagation()}
                 onClick={(e) => {
                   e.stopPropagation();
                   setShowCalendarModal(true);
@@ -173,7 +173,7 @@ const ToDoItem = ({
             )}
           </div>
 
-          <div className={styles['todoActionsHover']} onClick={(e) => e.stopPropagation()}>
+          <div className={styles['todoActionsHover']} onPointerDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()}>
             {!task.done && (
               <>
                 {activePomodoroId === null && (
@@ -210,7 +210,7 @@ const ToDoItem = ({
             </button>
           </div>
 
-          <div className={styles.mobileRight}>
+          <div className={styles.mobileRight} onPointerDown={(e) => e.stopPropagation()}>
             {resolvedCategory && (() => {
               const Icon = ICON_MAP[resolvedCategory.icon as CategoryIcon] ?? Briefcase;
               return (

--- a/client/src/components/UserSettings/UserSettings.module.css
+++ b/client/src/components/UserSettings/UserSettings.module.css
@@ -3,6 +3,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
+	animation: fadeSlideIn 0.3s ease both;
 }
 
 .activeHeader {
@@ -10,6 +11,8 @@
 	font-size: 10px;
 	justify-content: space-between;
 	align-items: center;
+	animation: fadeSlideIn 0.3s ease both;
+	animation-delay: 0ms;
 
 	h2 {
 		font-size: 16px;
@@ -26,7 +29,12 @@
 	background-color: var(--bg-todo-item);
 
 	overflow: hidden;
+	animation: fadeSlideIn 0.3s ease both;
 }
+
+.section:nth-child(2) { animation-delay: 60ms; }
+.section:nth-child(3) { animation-delay: 120ms; }
+.section:nth-child(4) { animation-delay: 180ms; }
 
 .section h3 {
 	font-size: 16px;
@@ -456,6 +464,11 @@ input:focus {
 		opacity: 1;
 		transform: translateY(0);
 	}
+}
+
+@keyframes fadeSlideIn {
+	from { opacity: 0; transform: translateY(10px); }
+	to   { opacity: 1; transform: translateY(0); }
 }
 
 @media (min-width: 768px) {

--- a/client/src/pages/MainContent/MainContent.tsx
+++ b/client/src/pages/MainContent/MainContent.tsx
@@ -108,7 +108,7 @@ const MainContent = () => {
           />
         );
       case 'completed':
-        return <CompletedTasks />;
+        return <CompletedTasks categories={categories} />;
       case 'settings':
         return <UserSettings isFullscreen={isFullscreen} setIsFullscreen={setIsFullscreen} />;
       default:

--- a/client/src/pages/MainContent/MainContent.tsx
+++ b/client/src/pages/MainContent/MainContent.tsx
@@ -5,10 +5,17 @@ import styles from './MainContent.module.css';
 import ActiveTasks from '../../components/ActiveTasks';
 import CompletedTasks from '../../components/CompletedTasks/CompletedTasks';
 import UserSettings from '../../components/UserSettings/UserSettings';
+import CategoryModal from '../../components/CategoryModal/CategoryModal';
 import { getPomodoro } from '../../api/taskApi';
+import {
+  fetchCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from '../../api/categoryApi';
 import { useAuth } from '../../context/AuthContext';
 import { updateUserSettings } from '../../api/auth';
-import type { PomoData } from '../../types';
+import type { PomoData, Category } from '../../types';
 
 type Tab = 'active' | 'completed' | 'settings';
 
@@ -42,6 +49,51 @@ const MainContent = () => {
   const [activePomodoroId, setActivePomodoroId] = useState<number | null>(null);
   const [activePomoData, setActivePomoData] = useState<PomoData | null>(null);
 
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<number | null>(null);
+  const [showCategoryModal, setShowCategoryModal] = useState(false);
+  const [editingCategory, setEditingCategory] = useState<Category | null>(null);
+
+  const loadCategories = async () => {
+    const data = await fetchCategories();
+    setCategories(data);
+  };
+
+  useEffect(() => {
+    loadCategories();
+  }, []);
+
+  const handleCategorySelect = (id: number | null) => {
+    setSelectedCategoryId(id);
+    if (id !== null) setActiveTab('active');
+  };
+
+  const handleCategoryCreate = () => {
+    setEditingCategory(null);
+    setShowCategoryModal(true);
+  };
+
+  const handleCategoryUpdate = (cat: Category) => {
+    setEditingCategory(cat);
+    setShowCategoryModal(true);
+  };
+
+  const handleCategoryDelete = async (id: number) => {
+    await deleteCategory(id);
+    if (selectedCategoryId === id) setSelectedCategoryId(null);
+    await loadCategories();
+  };
+
+  const handleCategorySave = async (name: string, color: string, icon: string) => {
+    if (editingCategory) {
+      await updateCategory(editingCategory.id, { name, color, icon });
+    } else {
+      await createCategory(name, color, icon);
+    }
+    setShowCategoryModal(false);
+    await loadCategories();
+  };
+
   const renderContent = () => {
     switch (activeTab) {
       case 'active':
@@ -51,6 +103,8 @@ const MainContent = () => {
             setActivePomodoroId={setActivePomodoroId}
             activePomoData={activePomoData}
             setActivePomoData={setActivePomoData}
+            categories={categories}
+            selectedCategoryId={selectedCategoryId}
           />
         );
       case 'completed':
@@ -103,12 +157,26 @@ const MainContent = () => {
               onTabChange={(tab) => setActiveTab(tab as Tab)}
               isOpen={isMenuOpen}
               onClose={() => setIsMenuOpen(false)}
+              categories={categories}
+              selectedCategoryId={selectedCategoryId}
+              onCategorySelect={handleCategorySelect}
+              onCategoryCreate={handleCategoryCreate}
+              onCategoryUpdate={handleCategoryUpdate}
+              onCategoryDelete={handleCategoryDelete}
             />
 
             <main className={styles.dashboardContent}>{renderContent()}</main>
           </div>
         </div>
       </div>
+
+      {showCategoryModal && (
+        <CategoryModal
+          category={editingCategory ?? undefined}
+          onSave={handleCategorySave}
+          onClose={() => setShowCategoryModal(false)}
+        />
+      )}
     </div>
   );
 };

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -67,6 +67,7 @@ export interface Task {
   created: string;
   categoryId: number | null;
   category: Category | null;
+  sortOrder: number;
 }
 
 export interface PomoData {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -14,6 +14,50 @@ export interface User {
   settings?: UserSettings;
 }
 
+export interface Category {
+  id: number;
+  name: string;
+  color: string;
+  icon: string;
+  _count?: { tasks: number };
+}
+
+export type CategoryColor =
+  | '#ef4444'
+  | '#f97316'
+  | '#eab308'
+  | '#22c55e'
+  | '#14b8a6'
+  | '#3b82f6'
+  | '#8b5cf6'
+  | '#ec4899'
+  | '#64748b'
+  | '#84cc16'
+  | '#06b6d4'
+  | '#f43f5e';
+
+export type CategoryIcon =
+  | 'Briefcase'
+  | 'Home'
+  | 'Book'
+  | 'Heart'
+  | 'Star'
+  | 'ShoppingCart'
+  | 'Dumbbell'
+  | 'Code'
+  | 'Music'
+  | 'Camera'
+  | 'Plane'
+  | 'Car'
+  | 'Coffee'
+  | 'Gamepad2'
+  | 'Palette'
+  | 'Globe'
+  | 'Leaf'
+  | 'Zap'
+  | 'Target'
+  | 'Users';
+
 export interface Task {
   id: number;
   title: string;
@@ -21,6 +65,8 @@ export interface Task {
   done: boolean;
   scheduled: string | null;
   created: string;
+  categoryId: number | null;
+  category: Category | null;
 }
 
 export interface PomoData {

--- a/server/src/api/task.controller.ts
+++ b/server/src/api/task.controller.ts
@@ -54,9 +54,9 @@ export async function addTaskController(
   const { task_name, task_desc } = request.body;
 
   const userData = await getUserData(request.server.prisma, request.user.email);
-  await addTask(request.server.prisma, userData.id, task_name, task_desc);
+  const task = await addTask(request.server.prisma, userData.id, task_name, task_desc);
 
-  return reply.ok("NEW_TASK_ADDED");
+  return reply.code(201).send({ id: task?.id });
 }
 
 export async function modifyTaskController(

--- a/server/src/api/task.controller.ts
+++ b/server/src/api/task.controller.ts
@@ -11,6 +11,7 @@ import {
   startPomo,
   pauseOrResumePomo,
   endPomo,
+  reorderTasks,
 } from "./task.service";
 
 import type {
@@ -25,6 +26,7 @@ import type {
   IEndPomoRequest,
   IGetPomoHistoryRequest,
   IDeletePomoRecordRequest,
+  IReorderTasksRequest,
 } from "@server/interfaces/ITask";
 
 import type { FastifyRequest, FastifyReply } from "fastify";
@@ -175,4 +177,20 @@ export async function endPomoController(
   await endPomo(request.server.prisma, task_id, userData.id);
 
   return reply.ok("POMO_ENDED");
+}
+
+export async function reorderTasksController(
+  request: FastifyRequest<IReorderTasksRequest>,
+  reply: FastifyReply,
+) {
+  const { items } = request.body;
+
+  const userData = await getUserData(request.server.prisma, request.user.email);
+  await reorderTasks(
+    request.server.prisma,
+    userData.id,
+    items.map((i) => ({ taskId: i.task_id, sortOrder: i.sort_order })),
+  );
+
+  return reply.ok("TASKS_REORDERED");
 }

--- a/server/src/api/task.repository.ts
+++ b/server/src/api/task.repository.ts
@@ -118,6 +118,16 @@ const tasksRepository = (prisma: PrismaClient) => ({
     prisma.pomo.deleteMany({
       where: { id: pomoId, userId },
     }),
+
+  reorderTasks: (userId: string, items: { taskId: number; sortOrder: number }[]) =>
+    prisma.$transaction(
+      items.map(({ taskId, sortOrder }) =>
+        prisma.tasks.update({
+          where: { id: taskId, userId },
+          data: { sortOrder },
+        }),
+      ),
+    ),
 });
 
 export default tasksRepository;

--- a/server/src/api/task.routes.ts
+++ b/server/src/api/task.routes.ts
@@ -10,6 +10,7 @@ import {
   pausePomoController,
   resumePomoController,
   endPomoController,
+  reorderTasksController,
 } from "./task.controller";
 
 import {
@@ -24,6 +25,7 @@ import {
   pausePomoSchema,
   resumePomoSchema,
   endPomoSchema,
+  reorderTasksSchema,
 } from "./task.schema";
 
 import type { FastifyInstance } from "fastify";
@@ -54,6 +56,15 @@ export default async function taskRoutes(fastify: FastifyInstance) {
       schema: modifyTaskSchema,
     },
     modifyTaskController,
+  );
+
+  fastify.patch(
+    "/reorder",
+    {
+      preHandler: [fastify.userAccessOnly],
+      schema: reorderTasksSchema,
+    },
+    reorderTasksController,
   );
 
   fastify.delete(

--- a/server/src/api/task.schema.ts
+++ b/server/src/api/task.schema.ts
@@ -98,3 +98,26 @@ export const deletePomoRecordSchema = {
     },
   },
 };
+
+export const reorderTasksSchema = {
+  body: {
+    type: "object",
+    required: ["items"],
+    additionalProperties: false,
+    properties: {
+      items: {
+        type: "array",
+        minItems: 1,
+        items: {
+          type: "object",
+          required: ["task_id", "sort_order"],
+          additionalProperties: false,
+          properties: {
+            task_id: { type: "number" },
+            sort_order: { type: "number", minimum: 0 },
+          },
+        },
+      },
+    },
+  },
+};

--- a/server/src/api/task.service.ts
+++ b/server/src/api/task.service.ts
@@ -171,6 +171,19 @@ export async function getPomoHistory(prisma: PrismaClient, userId: string) {
   }
 }
 
+export async function reorderTasks(
+  prisma: PrismaClient,
+  userId: string,
+  items: { taskId: number; sortOrder: number }[],
+) {
+  try {
+    return await repository(prisma).reorderTasks(userId, items);
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    handlePrismaError(err);
+  }
+}
+
 export async function endPomo(
   prisma: PrismaClient,
   taskId: number,

--- a/server/src/interfaces/ITask.ts
+++ b/server/src/interfaces/ITask.ts
@@ -44,6 +44,10 @@ export interface TaskModifyData {
   isFinished?: boolean;
 }
 
+export interface IReorderTasksRequest {
+  Body: { items: { task_id: number; sort_order: number }[] };
+}
+
 export type IEndPomoRequest = IGetPomoRequest;
 export type IPausePomoRequest = IGetPomoRequest;
 export type IResumePomoRequest = IGetPomoRequest;


### PR DESCRIPTION
Client-side Categories - full implementation    

<img width="1327" height="854" alt="image" src="https://github.com/user-attachments/assets/784198f6-94d0-427b-839c-2f87cbb94158" />
<img width="1338" height="848" alt="image" src="https://github.com/user-attachments/assets/f6d92c8e-acb3-42f4-8981-ee37b9dafed7" />
                         

 Added full category support on the client, building on top of the categories backend that was added in the your PR (b74060f).

  ---
  Had to do a server task controller fix.

  There was one blocker: when creating a new task, the plan was to create the task first, get its id back, then immediately patch it with the categoryId. The problem is that addTaskController was returning reply.ok("NEW_TASK_ADDED") — just a success message string, no task data. So created.id was always undefined on the client and the category never got assigned.

  The fix was one line in task.controller.ts: capture the return value of addTask(...) and send back { id: task.id } with a 201 status instead of the string message. The service and repository were already returning the created record — the controller was just throwing it away.

---

Check this out and tell what do you think. If ok - feel free to merge.