### PR TITLE
add tags UI

### DIFF
--- a/client/src/api/__tests__/tagApi.test.ts
+++ b/client/src/api/__tests__/tagApi.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  fetchTags,
+  createTag,
+  updateTag,
+  deleteTag,
+  addTagToTask,
+  removeTagFromTask,
+  fetchTasksByTags,
+} from '../tagApi';
+
+const mockOk = (body: unknown) =>
+  vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(body) });
+
+const mockFail = () =>
+  vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve(null) });
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('fetchTags', () => {
+  it('returns tag array on success', async () => {
+    const tags = [{ id: 1, name: 'urgent', color: '#ef4444' }];
+    vi.stubGlobal('fetch', mockOk(tags));
+
+    const result = await fetchTags();
+    expect(result).toEqual(tags);
+  });
+
+  it('returns empty array on failure', async () => {
+    vi.stubGlobal('fetch', mockFail());
+
+    const result = await fetchTags();
+    expect(result).toEqual([]);
+  });
+});
+
+describe('createTag', () => {
+  it('sends name and color in request body', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', mockFetch);
+
+    await createTag('urgent', '#ef4444');
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ name: 'urgent', color: '#ef4444' });
+  });
+
+  it('uses POST method', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', mockFetch);
+
+    await createTag('urgent', '#ef4444');
+
+    expect(mockFetch.mock.calls[0][1].method).toBe('POST');
+  });
+});
+
+describe('updateTag', () => {
+  it('sends tag_id and data wrapper in request body', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', mockFetch);
+
+    await updateTag(3, { name: 'renamed', color: '#3b82f6' });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.tag_id).toBe(3);
+    expect(body.data).toEqual({ name: 'renamed', color: '#3b82f6' });
+  });
+
+  it('uses PATCH method', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', mockFetch);
+
+    await updateTag(3, { name: 'renamed' });
+
+    expect(mockFetch.mock.calls[0][1].method).toBe('PATCH');
+  });
+
+  it('allows partial data (name only)', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', mockFetch);
+
+    await updateTag(3, { name: 'only-name' });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.data).toEqual({ name: 'only-name' });
+    expect(body.data.color).toBeUndefined();
+  });
+});
+
+describe('deleteTag', () => {
+  it('sends tag_id in request body', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', mockFetch);
+
+    await deleteTag(5);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.tag_id).toBe(5);
+  });
+
+  it('uses DELETE method', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', mockFetch);
+
+    await deleteTag(5);
+
+    expect(mockFetch.mock.calls[0][1].method).toBe('DELETE');
+  });
+});
+
+describe('addTagToTask', () => {
+  it('sends task_id and tag_id in request body', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await addTagToTask(10, 2);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ task_id: 10, tag_id: 2 });
+  });
+
+  it('uses POST method', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await addTagToTask(10, 2);
+
+    expect(mockFetch.mock.calls[0][1].method).toBe('POST');
+  });
+});
+
+describe('removeTagFromTask', () => {
+  it('sends task_id and tag_id in request body', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', mockFetch);
+
+    await removeTagFromTask(10, 2);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ task_id: 10, tag_id: 2 });
+  });
+
+  it('uses DELETE method', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({});
+    vi.stubGlobal('fetch', mockFetch);
+
+    await removeTagFromTask(10, 2);
+
+    expect(mockFetch.mock.calls[0][1].method).toBe('DELETE');
+  });
+});
+
+describe('fetchTasksByTags', () => {
+  const serverTask = {
+    id: 1,
+    taskName: 'Buy milk',
+    taskDesc: 'From the store',
+    isFinished: false,
+    scheduled: null,
+    created: '2024-01-01T00:00:00.000Z',
+    categoryId: null,
+    category: null,
+    sortOrder: 0,
+    tags: [{ id: 2, name: 'urgent', color: '#ef4444' }],
+  };
+
+  it('maps server field names to client field names', async () => {
+    vi.stubGlobal('fetch', mockOk([serverTask]));
+
+    const tasks = await fetchTasksByTags([2]);
+
+    expect(tasks[0].title).toBe('Buy milk');
+    expect(tasks[0].description).toBe('From the store');
+    expect(tasks[0].done).toBe(false);
+    expect(tasks[0].tags).toEqual(serverTask.tags);
+  });
+
+  it('builds query string with multiple tag_ids', async () => {
+    const mockFetch = mockOk([]);
+    vi.stubGlobal('fetch', mockFetch);
+
+    await fetchTasksByTags([1, 2, 3]);
+
+    const url: string = mockFetch.mock.calls[0][0];
+    expect(url).toContain('tag_ids=1');
+    expect(url).toContain('tag_ids=2');
+    expect(url).toContain('tag_ids=3');
+  });
+
+  it('returns empty array without fetching when tagIds is empty', async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await fetchTasksByTags([]);
+
+    expect(result).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array on failure', async () => {
+    vi.stubGlobal('fetch', mockFail());
+
+    const result = await fetchTasksByTags([1]);
+    expect(result).toEqual([]);
+  });
+});

--- a/client/src/api/__tests__/taskApi.test.ts
+++ b/client/src/api/__tests__/taskApi.test.ts
@@ -9,6 +9,10 @@ const serverTask = {
   isFinished: false,
   scheduled: null,
   created: '2024-01-01T00:00:00.000Z',
+  categoryId: null,
+  category: null,
+  sortOrder: 0,
+  tags: [],
 };
 
 // What our client Task type expects after mapping
@@ -19,6 +23,10 @@ const clientTask = {
   done: false,
   scheduled: null,
   created: '2024-01-01T00:00:00.000Z',
+  categoryId: null,
+  category: null,
+  sortOrder: 0,
+  tags: [],
 };
 
 beforeEach(() => {

--- a/client/src/api/tagApi.ts
+++ b/client/src/api/tagApi.ts
@@ -1,0 +1,96 @@
+import type { Category, Tag, Task } from '../types';
+
+const API = `${import.meta.env.VITE_API_URL}/api/tags`;
+
+interface ServerTask {
+  id: number;
+  taskName: string;
+  taskDesc: string;
+  isFinished: boolean;
+  scheduled: string | null;
+  created: string;
+  categoryId: number | null;
+  category: Category | null;
+  sortOrder?: number;
+  tags?: Tag[];
+}
+
+export async function fetchTags(): Promise<Tag[]> {
+  const res = await fetch(API, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!res.ok) return [];
+  return res.json() as Promise<Tag[]>;
+}
+
+export async function createTag(name: string, color: string): Promise<void> {
+  await fetch(API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ name, color }),
+  });
+}
+
+export async function updateTag(
+  tagId: number,
+  data: Partial<{ name: string; color: string }>,
+): Promise<void> {
+  await fetch(API, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ tag_id: tagId, data }),
+  });
+}
+
+export async function deleteTag(tagId: number): Promise<void> {
+  await fetch(API, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ tag_id: tagId }),
+  });
+}
+
+export async function addTagToTask(taskId: number, tagId: number): Promise<Response> {
+  return fetch(`${API}/tasks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ task_id: taskId, tag_id: tagId }),
+  });
+}
+
+export async function removeTagFromTask(taskId: number, tagId: number): Promise<void> {
+  await fetch(`${API}/tasks`, {
+    method: 'DELETE',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ task_id: taskId, tag_id: tagId }),
+  });
+}
+
+export async function fetchTasksByTags(tagIds: number[]): Promise<Task[]> {
+  if (tagIds.length === 0) return [];
+  const qs = tagIds.map((id) => `tag_ids=${id}`).join('&');
+  const res = await fetch(`${API}/tasks?${qs}`, {
+    method: 'GET',
+    credentials: 'include',
+  });
+  if (!res.ok) return [];
+  const data = (await res.json()) as ServerTask[];
+  return data.map((task) => ({
+    id: task.id,
+    title: task.taskName,
+    description: task.taskDesc,
+    done: task.isFinished,
+    scheduled: task.scheduled,
+    created: task.created,
+    categoryId: task.categoryId,
+    category: task.category,
+    sortOrder: task.sortOrder ?? 0,
+    tags: task.tags ?? [],
+  }));
+}

--- a/client/src/api/taskApi.ts
+++ b/client/src/api/taskApi.ts
@@ -1,4 +1,4 @@
-import type { Task, PomoData, PomoRecord } from '../types';
+import type { Task, PomoData, PomoRecord, Tag } from '../types';
 
 const API = `${import.meta.env.VITE_API_URL}/api/task`;
 
@@ -12,6 +12,7 @@ interface ServerTask {
   categoryId?: number | null;
   category?: import('../types').Category | null;
   sortOrder?: number;
+  tags?: Tag[];
 }
 
 interface TaskUpdate {
@@ -40,6 +41,7 @@ export async function fetchTasks(): Promise<Task[]> {
     categoryId: task.categoryId ?? null,
     category: task.category ?? null,
     sortOrder: task.sortOrder ?? 0,
+    tags: task.tags ?? [],
   }));
 }
 

--- a/client/src/components/ActiveTasks/ActiveTasks.tsx
+++ b/client/src/components/ActiveTasks/ActiveTasks.tsx
@@ -7,7 +7,8 @@ import {
   reorderTasks,
 } from '../../api/taskApi';
 import { fetchTasksByCategory } from '../../api/categoryApi';
-import type { Task, PomoData, Category } from '../../types';
+import { fetchTasksByTags, addTagToTask, removeTagFromTask } from '../../api/tagApi';
+import type { Task, PomoData, Category, Tag } from '../../types';
 import { DragDropProvider, DragOverlay } from '@dnd-kit/react';
 import type { DragEndEvent } from '@dnd-kit/react';
 import { move } from '@dnd-kit/helpers';
@@ -29,6 +30,8 @@ interface ActiveTasksProps {
   setActivePomoData: (data: PomoData | null) => void;
   categories: Category[];
   selectedCategoryId: number | null;
+  tags: Tag[];
+  selectedTagIds: number[];
 }
 
 const ActiveTasks = ({
@@ -38,6 +41,8 @@ const ActiveTasks = ({
   setActivePomoData,
   categories,
   selectedCategoryId,
+  tags,
+  selectedTagIds,
 }: ActiveTasksProps) => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
@@ -60,10 +65,17 @@ const ActiveTasks = ({
   const loadTasks = async () => {
     setLoading(true);
     try {
-      const data =
-        selectedCategoryId !== null
-          ? await fetchTasksByCategory(selectedCategoryId)
-          : await fetchTasks();
+      let data: Task[];
+      if (selectedTagIds.length > 0) {
+        data = await fetchTasksByTags(selectedTagIds);
+        if (selectedCategoryId !== null) {
+          data = data.filter((t) => t.categoryId === selectedCategoryId);
+        }
+      } else if (selectedCategoryId !== null) {
+        data = await fetchTasksByCategory(selectedCategoryId);
+      } else {
+        data = await fetchTasks();
+      }
       setTasks(data);
     } finally {
       setLoading(false);
@@ -72,21 +84,37 @@ const ActiveTasks = ({
 
   useEffect(() => {
     loadTasks();
-  }, [selectedCategoryId]);
+  }, [selectedCategoryId, selectedTagIds.join(',')]);
+
+  const applyTagsToTask = async (taskId: number, tagIds: number[]) => {
+    for (const tagId of tagIds) {
+      const res = await addTagToTask(taskId, tagId);
+      if (!res.ok && res.status !== 409) {
+        // 409 = already on task: ignore. Other errors stop further assignments.
+        break;
+      }
+    }
+  };
 
   const addTask = async ({
     title,
     description,
     categoryId,
+    tagIds,
   }: {
     title: string;
     description: string;
     categoryId: number | null;
+    tagIds: number[];
   }) => {
     try {
       const created = await apiAddTask(title, description);
-      if (categoryId !== null && created?.id) {
+      if (!created?.id) return;
+      if (categoryId !== null) {
         await apiEditTask(created.id, { categoryId });
+      }
+      if (tagIds.length > 0) {
+        await applyTagsToTask(created.id, tagIds);
       }
     } finally {
       await loadTasks();
@@ -114,7 +142,24 @@ const ActiveTasks = ({
 
   const updateTask = async (id: number, data: Record<string, unknown>) => {
     try {
-      await apiEditTask(id, data as Parameters<typeof apiEditTask>[1]);
+      const { tagIds, originalTagIds, ...rest } = data as {
+        tagIds?: number[];
+        originalTagIds?: number[];
+        [key: string]: unknown;
+      };
+
+      if (Object.keys(rest).length > 0) {
+        await apiEditTask(id, rest as Parameters<typeof apiEditTask>[1]);
+      }
+
+      if (tagIds && originalTagIds) {
+        const toAdd = tagIds.filter((tid) => !originalTagIds.includes(tid));
+        const toRemove = originalTagIds.filter((tid) => !tagIds.includes(tid));
+        await Promise.all([
+          ...toRemove.map((tid) => removeTagFromTask(id, tid)),
+          ...toAdd.map((tid) => addTagToTask(id, tid)),
+        ]);
+      }
     } finally {
       await loadTasks();
     }
@@ -130,9 +175,18 @@ const ActiveTasks = ({
   };
 
   const activeCategory = categories.find((c) => c.id === selectedCategoryId);
-  const headerLabel = activeCategory
-    ? `${activeCategory.name} (${activeTasks.length})`
-    : `Active tasks (${activeTasks.length})`;
+  const activeTagNames = tags
+    .filter((t) => selectedTagIds.includes(t.id))
+    .map((t) => `#${t.name}`)
+    .join(', ');
+
+  const headerLabel = (() => {
+    const count = `(${activeTasks.length})`;
+    if (activeCategory && activeTagNames) return `${activeCategory.name} · ${activeTagNames} ${count}`;
+    if (activeCategory) return `${activeCategory.name} ${count}`;
+    if (activeTagNames) return `${activeTagNames} ${count}`;
+    return `Active tasks ${count}`;
+  })();
 
   return (
     <div className={styles.container}>
@@ -150,7 +204,12 @@ const ActiveTasks = ({
           <div className={styles.emptyState}>
             <div className={styles.emptyContainer}>
               <Search size={68} />
-              {selectedCategoryId !== null ? (
+              {selectedTagIds.length > 0 ? (
+                <>
+                  <h3>No tasks with these tags</h3>
+                  <p>Try removing some tag filters or assign these tags to a task</p>
+                </>
+              ) : selectedCategoryId !== null ? (
                 <>
                   <h3>No tasks in this category</h3>
                   <p>Add this category to an existing task or create a new one</p>
@@ -179,6 +238,7 @@ const ActiveTasks = ({
                 activePomoData={activePomoData}
                 setActivePomoData={setActivePomoData}
                 categories={categories}
+                tags={tags}
               />
             ))}
             <DragOverlay dropAnimation={null}>
@@ -217,7 +277,9 @@ const ActiveTasks = ({
           onAdd={addTask}
           onClose={() => setShowCreateModal(false)}
           categories={categories}
+          tags={tags}
           defaultCategoryId={selectedCategoryId}
+          defaultTagIds={selectedTagIds}
         />
       )}
 

--- a/client/src/components/AddTaskModal/AddTaskModal.tsx
+++ b/client/src/components/AddTaskModal/AddTaskModal.tsx
@@ -1,19 +1,35 @@
 import { useState } from 'react';
 import { X, Plus, AlertCircle } from 'lucide-react';
-import type { Category } from '../../types';
+import type { Category, Tag } from '../../types';
+import TagChipPicker from '../TagChipPicker/TagChipPicker';
 import styles from './AddTaskModal.module.css';
 
 interface AddTaskModalProps {
-  onAdd: (task: { title: string; description: string; categoryId: number | null }) => void;
+  onAdd: (task: {
+    title: string;
+    description: string;
+    categoryId: number | null;
+    tagIds: number[];
+  }) => void;
   onClose: () => void;
   categories: Category[];
+  tags: Tag[];
   defaultCategoryId?: number | null;
+  defaultTagIds?: number[];
 }
 
-const AddTaskModal = ({ onAdd, onClose, categories, defaultCategoryId }: AddTaskModalProps) => {
+const AddTaskModal = ({
+  onAdd,
+  onClose,
+  categories,
+  tags,
+  defaultCategoryId,
+  defaultTagIds,
+}: AddTaskModalProps) => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [categoryId, setCategoryId] = useState<number | null>(defaultCategoryId ?? null);
+  const [tagIds, setTagIds] = useState<number[]>(defaultTagIds ?? []);
   const [inputError, setInputError] = useState('');
   const [serverError, setServerError] = useState('');
 
@@ -39,11 +55,12 @@ const AddTaskModal = ({ onAdd, onClose, categories, defaultCategoryId }: AddTask
       return;
     }
 
-    onAdd({ title, description, categoryId });
+    onAdd({ title, description, categoryId, tagIds });
 
     setTitle('');
     setDescription('');
     setCategoryId(null);
+    setTagIds([]);
     setInputError('');
     setServerError('');
     onClose();
@@ -112,6 +129,12 @@ const AddTaskModal = ({ onAdd, onClose, categories, defaultCategoryId }: AddTask
                   </option>
                 ))}
               </select>
+            </div>
+          )}
+
+          {tags.length > 0 && (
+            <div className={styles.inputGroup}>
+              <TagChipPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
             </div>
           )}
 

--- a/client/src/components/AddTaskModal/__tests__/AddTaskModal.test.tsx
+++ b/client/src/components/AddTaskModal/__tests__/AddTaskModal.test.tsx
@@ -52,7 +52,7 @@ describe('AddTaskModal — submission', () => {
     await userEvent.type(screen.getByPlaceholderText(/enter description/i), 'From the store');
     await userEvent.click(screen.getByRole('button', { name: /add task/i }));
 
-    expect(onAdd).toHaveBeenCalledWith({ title: 'Buy milk', description: 'From the store', categoryId: null });
+    expect(onAdd).toHaveBeenCalledWith({ title: 'Buy milk', description: 'From the store', categoryId: null, tagIds: [] });
   });
 
   it('calls onClose after successful submit', async () => {

--- a/client/src/components/AddTaskModal/__tests__/AddTaskModal.test.tsx
+++ b/client/src/components/AddTaskModal/__tests__/AddTaskModal.test.tsx
@@ -7,7 +7,7 @@ import AddTaskModal from '../AddTaskModal';
 function setup() {
   const onAdd = vi.fn();
   const onClose = vi.fn();
-  render(<AddTaskModal onAdd={onAdd} onClose={onClose} categories={[]} />);
+  render(<AddTaskModal onAdd={onAdd} onClose={onClose} categories={[]} tags={[]} />);
   return { onAdd, onClose };
 }
 

--- a/client/src/components/CategoryModal/CategoryModal.tsx
+++ b/client/src/components/CategoryModal/CategoryModal.tsx
@@ -103,6 +103,7 @@ const CategoryModal = ({ category, onSave, onClose }: CategoryModalProps) => {
   const validate = (value: string): string => {
     if (!value.trim()) return 'Name is required';
     if (value.length > 15) return 'Name must be 15 characters or less';
+    if (!/^[\p{L}\p{N}\s\-]+$/u.test(value.trim())) return 'Only letters, numbers, spaces and hyphens allowed';
     return '';
   };
 

--- a/client/src/components/CategoryModal/__tests__/CategoryModal.test.tsx
+++ b/client/src/components/CategoryModal/__tests__/CategoryModal.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CategoryModal from '../CategoryModal';
+
+function setup(category?: { id: number; name: string; color: string; icon: string }) {
+  const onSave = vi.fn();
+  const onClose = vi.fn();
+  render(<CategoryModal category={category} onSave={onSave} onClose={onClose} />);
+  return { onSave, onClose };
+}
+
+const getInput = () => screen.getByLabelText('Name');
+
+describe('CategoryModal — validation', () => {
+  it('shows "Name is required" when submitting empty form', async () => {
+    setup();
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+  });
+
+  it('shows error for name longer than 15 characters', async () => {
+    setup();
+    fireEvent.change(getInput(), { target: { value: 'a'.repeat(16) } });
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText(/15 characters or less/i)).toBeInTheDocument();
+  });
+
+  it('shows error for special characters', async () => {
+    setup();
+    await userEvent.type(getInput(), 'work@home');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText(/only letters/i)).toBeInTheDocument();
+  });
+
+  it('accepts letters, numbers, spaces and hyphens', async () => {
+    const { onSave } = setup();
+    await userEvent.type(getInput(), 'Work-2');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('clears error while typing a valid correction', async () => {
+    setup();
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+
+    await userEvent.type(getInput(), 'Work');
+    expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+  });
+});
+
+describe('CategoryModal — submission', () => {
+  it('calls onSave with trimmed name, color and icon', async () => {
+    const { onSave } = setup();
+    await userEvent.type(getInput(), 'Work');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(onSave).toHaveBeenCalledWith('Work', expect.any(String), expect.any(String));
+  });
+
+  it('does not call onSave when name is invalid', async () => {
+    const { onSave } = setup();
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('shows "Save changes" button when editing an existing category', () => {
+    setup({ id: 1, name: 'Work', color: '#3b82f6', icon: 'Briefcase' });
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+  });
+
+  it('pre-fills name field when editing', () => {
+    setup({ id: 1, name: 'Work', color: '#3b82f6', icon: 'Briefcase' });
+    expect(getInput()).toHaveValue('Work');
+  });
+});
+
+describe('CategoryModal — close behavior', () => {
+  it('calls onClose when Cancel is clicked', async () => {
+    const { onClose } = setup();
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/client/src/components/CompletedTasks/CompletedTasks.tsx
+++ b/client/src/components/CompletedTasks/CompletedTasks.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchTasks, editTask as apiEditTask, deleteTask as apiDeleteTask } from '../../api/taskApi';
-import type { Task, Category } from '../../types';
+import type { Task, Category, Tag } from '../../types';
 
 import ToDoItem from '../ToDoItem';
 import DeleteAllButton from '../DeleteAllButton';
@@ -12,9 +12,10 @@ import styles from './CompletedTasks.module.css';
 
 interface CompletedTasksProps {
   categories: Category[];
+  tags: Tag[];
 }
 
-const CompletedTasks = ({ categories }: CompletedTasksProps) => {
+const CompletedTasks = ({ categories, tags }: CompletedTasksProps) => {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -112,6 +113,7 @@ const CompletedTasks = ({ categories }: CompletedTasksProps) => {
               activePomoData={null}
               setActivePomoData={() => {}}
               categories={categories}
+              tags={tags}
             />
           ))
         )}

--- a/client/src/components/CompletedTasks/CompletedTasks.tsx
+++ b/client/src/components/CompletedTasks/CompletedTasks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { fetchTasks, editTask as apiEditTask, deleteTask as apiDeleteTask } from '../../api/taskApi';
+import { addTagToTask, removeTagFromTask } from '../../api/tagApi';
 import type { Task, Category, Tag } from '../../types';
 
 import ToDoItem from '../ToDoItem';
@@ -62,9 +63,26 @@ const CompletedTasks = ({ categories, tags }: CompletedTasksProps) => {
     }
   };
 
-  const updateTask = async (id: number, updates: Record<string, unknown>) => {
+  const updateTask = async (id: number, data: Record<string, unknown>) => {
     try {
-      await apiEditTask(id, updates as Parameters<typeof apiEditTask>[1]);
+      const { tagIds, originalTagIds, ...rest } = data as {
+        tagIds?: number[];
+        originalTagIds?: number[];
+        [key: string]: unknown;
+      };
+
+      if (Object.keys(rest).length > 0) {
+        await apiEditTask(id, rest as Parameters<typeof apiEditTask>[1]);
+      }
+
+      if (tagIds && originalTagIds) {
+        const toAdd = tagIds.filter((tid) => !originalTagIds.includes(tid));
+        const toRemove = originalTagIds.filter((tid) => !tagIds.includes(tid));
+        await Promise.all([
+          ...toRemove.map((tid) => removeTagFromTask(id, tid)),
+          ...toAdd.map((tid) => addTagToTask(id, tid)),
+        ]);
+      }
     } finally {
       await loadTasks();
     }

--- a/client/src/components/EditTaskModal/EditTaskModal.tsx
+++ b/client/src/components/EditTaskModal/EditTaskModal.tsx
@@ -1,19 +1,32 @@
 import { useState } from 'react';
 import { X, Pencil, AlertCircle } from 'lucide-react';
-import type { Task, Category } from '../../types';
+import type { Task, Category, Tag } from '../../types';
+import TagChipPicker from '../TagChipPicker/TagChipPicker';
 import styles from './EditTaskModal.module.css';
 
 interface EditTaskModalProps {
   task: Task;
-  onUpdate: (id: number, updates: { title: string; description: string; categoryId: number | null }) => void;
+  onUpdate: (
+    id: number,
+    updates: {
+      title: string;
+      description: string;
+      categoryId: number | null;
+      tagIds: number[];
+      originalTagIds: number[];
+    },
+  ) => void;
   onClose: () => void;
   categories: Category[];
+  tags: Tag[];
 }
 
-const EditTaskModal = ({ task, onUpdate, onClose, categories }: EditTaskModalProps) => {
+const EditTaskModal = ({ task, onUpdate, onClose, categories, tags }: EditTaskModalProps) => {
+  const originalTagIds = (task.tags ?? []).map((t) => t.id);
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description || '');
   const [categoryId, setCategoryId] = useState<number | null>(task.categoryId);
+  const [tagIds, setTagIds] = useState<number[]>(originalTagIds);
   const [inputError, setInputError] = useState('');
 
   const validateTitle = (value: string): string => {
@@ -37,7 +50,7 @@ const EditTaskModal = ({ task, onUpdate, onClose, categories }: EditTaskModalPro
       return;
     }
 
-    onUpdate(task.id, { title, description, categoryId });
+    onUpdate(task.id, { title, description, categoryId, tagIds, originalTagIds });
     onClose();
   };
 
@@ -102,6 +115,12 @@ const EditTaskModal = ({ task, onUpdate, onClose, categories }: EditTaskModalPro
                   </option>
                 ))}
               </select>
+            </div>
+          )}
+
+          {tags.length > 0 && (
+            <div className={styles.inputGroup}>
+              <TagChipPicker tags={tags} selectedIds={tagIds} onChange={setTagIds} />
             </div>
           )}
 

--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -186,19 +186,8 @@
 }
 
 .tagActive {
-	background: var(--sidebar-item-hover);
-	color: var(--text-primary);
-	font-weight: 500;
-}
-
-.tagActive::before {
-	content: '';
-	position: absolute;
-	left: 0;
-	width: 3px;
-	height: 60%;
-	background: var(--color-primary);
-	border-radius: 2px;
+	background: var(--color-primary) !important;
+	color: var(--sidebar-item-active-text, white);
 }
 
 .tagItem:hover .categoryActions,

--- a/client/src/components/Sidebar/Sidebar.module.css
+++ b/client/src/components/Sidebar/Sidebar.module.css
@@ -153,6 +153,93 @@
 	background: rgba(239, 68, 68, 0.12);
 }
 
+/* ── Tags section ─────────────────────────────── */
+.tagsSection {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	overflow-y: auto;
+	min-height: 0;
+	padding-right: 4px;
+	padding-bottom: 4px;
+}
+
+.tagItem {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 6px 8px;
+	border-radius: 10px;
+	border: none;
+	cursor: pointer;
+	width: 100%;
+	background: transparent;
+	color: var(--sidebar-item-text);
+	font-size: 13px;
+	text-align: left;
+	transition: background var(--transition), color var(--transition);
+	position: relative;
+}
+
+.tagItem:hover {
+	background: var(--sidebar-item-hover);
+}
+
+.tagActive {
+	background: var(--sidebar-item-hover);
+	color: var(--text-primary);
+	font-weight: 500;
+}
+
+.tagActive::before {
+	content: '';
+	position: absolute;
+	left: 0;
+	width: 3px;
+	height: 60%;
+	background: var(--color-primary);
+	border-radius: 2px;
+}
+
+.tagItem:hover .categoryActions,
+.tagActive .categoryActions {
+	display: flex;
+}
+
+.tagDot {
+	width: 12px;
+	height: 12px;
+	border-radius: 50%;
+	flex-shrink: 0;
+	margin-left: 4px;
+}
+
+.tagName {
+	flex: 1;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.clearTagsBtn {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	font-size: 11px;
+	padding: 4px 8px;
+	border-radius: 6px;
+	cursor: pointer;
+	margin-left: auto;
+}
+
+.clearTagsBtn:hover {
+	background: var(--sidebar-item-hover);
+	color: var(--text-primary);
+}
+
 .sidebarItem {
 	display: flex;
 	align-items: center;

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -1,8 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 import { logout } from '../../api/auth';
 import { ListTodo, CheckCircle2, X, Settings as SettingsIcon, LogOut, Plus } from 'lucide-react';
-import type { Category } from '../../types';
+import type { Category, Tag } from '../../types';
 import CategoryItem from './CategoryItem';
+import TagItem from './TagItem';
 import styles from './Sidebar.module.css';
 
 interface SidebarProps {
@@ -16,6 +17,13 @@ interface SidebarProps {
 	onCategoryCreate: () => void;
 	onCategoryUpdate: (category: Category) => void;
 	onCategoryDelete: (id: number) => void;
+	tags: Tag[];
+	selectedTagIds: number[];
+	onTagToggle: (id: number) => void;
+	onTagsClear: () => void;
+	onTagCreate: () => void;
+	onTagEdit: (tag: Tag) => void;
+	onTagDelete: (id: number) => void;
 }
 
 const Sidebar = ({
@@ -29,6 +37,13 @@ const Sidebar = ({
 	onCategoryCreate,
 	onCategoryUpdate,
 	onCategoryDelete,
+	tags,
+	selectedTagIds,
+	onTagToggle,
+	onTagsClear,
+	onTagCreate,
+	onTagEdit,
+	onTagDelete,
 }: SidebarProps) => {
 	const navigate = useNavigate();
 
@@ -99,6 +114,43 @@ const Sidebar = ({
 							}}
 							onEdit={() => onCategoryUpdate(cat)}
 							onDelete={() => onCategoryDelete(cat.id)}
+						/>
+					))}
+				</div>
+
+				<div className={styles.categoriesHeader}>
+					<span className={styles.categoriesLabel}>Tags</span>
+					{selectedTagIds.length > 0 && (
+						<button
+							className={styles.clearTagsBtn}
+							onClick={onTagsClear}
+							title='Clear tag filter'>
+							Clear
+						</button>
+					)}
+					<button
+						className={styles.addCategoryBtn}
+						onClick={() => {
+							onClose();
+							onTagCreate();
+						}}
+						title='New tag'>
+						<Plus size={15} />
+					</button>
+				</div>
+
+				<div className={styles.tagsSection}>
+					{tags.map((tag) => (
+						<TagItem
+							key={tag.id}
+							tag={tag}
+							isSelected={selectedTagIds.includes(tag.id)}
+							onToggle={() => {
+								onTagToggle(tag.id);
+								onTabChange('active');
+							}}
+							onEdit={() => onTagEdit(tag)}
+							onDelete={() => onTagDelete(tag.id)}
 						/>
 					))}
 				</div>

--- a/client/src/components/Sidebar/Sidebar.tsx
+++ b/client/src/components/Sidebar/Sidebar.tsx
@@ -162,6 +162,7 @@ const Sidebar = ({
 					onClick={() => {
 						onTabChange('completed');
 						onCategorySelect(null);
+						onTagsClear();
 						onClose();
 					}}>
 					<CheckCircle2 size={18} strokeWidth={2} />
@@ -174,6 +175,7 @@ const Sidebar = ({
 						onClick={() => {
 							onTabChange('settings');
 							onCategorySelect(null);
+							onTagsClear();
 							onClose();
 						}}>
 						<SettingsIcon size={18} strokeWidth={2} />

--- a/client/src/components/Sidebar/TagItem.tsx
+++ b/client/src/components/Sidebar/TagItem.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Trash2, Hash } from 'lucide-react';
 import type { Tag } from '../../types';
 import styles from './Sidebar.module.css';
 
@@ -15,8 +15,10 @@ const TagItem = ({ tag, isSelected, onToggle, onEdit, onDelete }: TagItemProps) 
     <button
       className={`${styles.tagItem} ${isSelected ? styles.tagActive : ''}`}
       onClick={onToggle}>
-      <span className={styles.tagDot} style={{ backgroundColor: tag.color }} />
-      <span className={styles.tagName}>#{tag.name}</span>
+      <span className={styles.categoryIcon} style={{ backgroundColor: tag.color }}>
+        <Hash size={14} strokeWidth={2} />
+      </span>
+      <span className={styles.tagName}>{tag.name}</span>
       <span className={styles.categoryActions}>
         <button
           className={styles.categoryActionBtn}

--- a/client/src/components/Sidebar/TagItem.tsx
+++ b/client/src/components/Sidebar/TagItem.tsx
@@ -1,0 +1,44 @@
+import { Pencil, Trash2 } from 'lucide-react';
+import type { Tag } from '../../types';
+import styles from './Sidebar.module.css';
+
+interface TagItemProps {
+  tag: Tag;
+  isSelected: boolean;
+  onToggle: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const TagItem = ({ tag, isSelected, onToggle, onEdit, onDelete }: TagItemProps) => {
+  return (
+    <button
+      className={`${styles.tagItem} ${isSelected ? styles.tagActive : ''}`}
+      onClick={onToggle}>
+      <span className={styles.tagDot} style={{ backgroundColor: tag.color }} />
+      <span className={styles.tagName}>#{tag.name}</span>
+      <span className={styles.categoryActions}>
+        <button
+          className={styles.categoryActionBtn}
+          onClick={(e) => {
+            e.stopPropagation();
+            onEdit();
+          }}
+          title='Edit'>
+          <Pencil size={13} />
+        </button>
+        <button
+          className={`${styles.categoryActionBtn} ${styles.categoryDeleteBtn}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          title='Delete'>
+          <Trash2 size={13} />
+        </button>
+      </span>
+    </button>
+  );
+};
+
+export default TagItem;

--- a/client/src/components/TagChipPicker/TagChipPicker.module.css
+++ b/client/src/components/TagChipPicker/TagChipPicker.module.css
@@ -9,7 +9,7 @@
 	align-items: center;
 	gap: 8px;
 	color: var(--text-secondary);
-	font-size: 14px;
+	font-size: 16px;
 }
 
 .limitNote {
@@ -54,9 +54,3 @@
 	transform: none;
 }
 
-.dot {
-	width: 9px;
-	height: 9px;
-	border-radius: 50%;
-	flex-shrink: 0;
-}

--- a/client/src/components/TagChipPicker/TagChipPicker.module.css
+++ b/client/src/components/TagChipPicker/TagChipPicker.module.css
@@ -1,0 +1,62 @@
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.label {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	color: var(--text-secondary);
+	font-size: 14px;
+}
+
+.limitNote {
+	font-size: 12px;
+	color: var(--color-red, #ef4444);
+}
+
+.chipList {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 5px 10px;
+	border-radius: 999px;
+	border: 1.5px solid var(--border-color);
+	background: var(--bg-surface);
+	color: var(--text-primary);
+	font-size: 13px;
+	cursor: pointer;
+	transition: var(--transition-duration);
+}
+
+.chip:hover {
+	transform: translateY(-1px);
+}
+
+.chipSelected {
+	font-weight: 600;
+}
+
+.chipDisabled {
+	opacity: 0.4;
+	cursor: not-allowed;
+}
+
+.chipDisabled:hover {
+	transform: none;
+}
+
+.dot {
+	width: 9px;
+	height: 9px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}

--- a/client/src/components/TagChipPicker/TagChipPicker.tsx
+++ b/client/src/components/TagChipPicker/TagChipPicker.tsx
@@ -25,7 +25,7 @@ const TagChipPicker = ({ tags, selectedIds, onChange }: TagChipPickerProps) => {
   return (
     <div className={styles.wrapper}>
       <div className={styles.label}>
-        Tags
+        Tags (optional)
         {atLimit && <span className={styles.limitNote}>Max {MAX_TAGS_PER_TASK} per task</span>}
       </div>
       <div className={styles.chipList}>
@@ -45,7 +45,7 @@ const TagChipPicker = ({ tags, selectedIds, onChange }: TagChipPickerProps) => {
                   : { borderColor: tag.color, color: tag.color }
               }>
               <span className={styles.dot} style={{ backgroundColor: tag.color }} />
-              {tag.name}
+              # {tag.name}
             </button>
           );
         })}

--- a/client/src/components/TagChipPicker/TagChipPicker.tsx
+++ b/client/src/components/TagChipPicker/TagChipPicker.tsx
@@ -1,0 +1,57 @@
+import type { Tag } from '../../types';
+import { MAX_TAGS_PER_TASK } from '../../types';
+import styles from './TagChipPicker.module.css';
+
+interface TagChipPickerProps {
+  tags: Tag[];
+  selectedIds: number[];
+  onChange: (ids: number[]) => void;
+}
+
+const TagChipPicker = ({ tags, selectedIds, onChange }: TagChipPickerProps) => {
+  if (tags.length === 0) return null;
+
+  const atLimit = selectedIds.length >= MAX_TAGS_PER_TASK;
+
+  const toggle = (id: number) => {
+    if (selectedIds.includes(id)) {
+      onChange(selectedIds.filter((x) => x !== id));
+    } else {
+      if (atLimit) return;
+      onChange([...selectedIds, id]);
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.label}>
+        Tags
+        {atLimit && <span className={styles.limitNote}>Max {MAX_TAGS_PER_TASK} per task</span>}
+      </div>
+      <div className={styles.chipList}>
+        {tags.map((tag) => {
+          const selected = selectedIds.includes(tag.id);
+          const disabled = !selected && atLimit;
+          return (
+            <button
+              key={tag.id}
+              type='button'
+              onClick={() => toggle(tag.id)}
+              disabled={disabled}
+              className={`${styles.chip} ${selected ? styles.chipSelected : ''} ${disabled ? styles.chipDisabled : ''}`}
+              style={
+                selected
+                  ? { borderColor: tag.color, color: tag.color, backgroundColor: `${tag.color}22` }
+                  : { borderColor: tag.color, color: tag.color }
+              }>
+              <span className={styles.dot} style={{ backgroundColor: tag.color }} />
+              {tag.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default TagChipPicker;

--- a/client/src/components/TagModal/TagModal.module.css
+++ b/client/src/components/TagModal/TagModal.module.css
@@ -1,0 +1,180 @@
+.overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.65);
+	backdrop-filter: blur(6px);
+	-webkit-backdrop-filter: blur(6px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 999;
+	animation: fadeIn 0.2s ease;
+}
+
+.modal {
+	width: 440px;
+	background: var(--bg-content);
+	border: 1px solid var(--border-color);
+	border-radius: var(--border-radius);
+	box-shadow: var(--shadow);
+	animation: scaleIn 0.2s ease;
+	overflow: hidden;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	background: var(--bg-surface);
+	padding: 16px 18px;
+	border-bottom: 1px solid var(--border-color);
+}
+
+.title {
+	color: var(--text-primary);
+	font-weight: 500;
+	font-size: 18px;
+}
+
+.closeBtn {
+	padding: 6px;
+	border: none;
+	background: transparent;
+	color: var(--text-muted);
+	cursor: pointer;
+	border-radius: 8px;
+	transition: var(--transition-duration);
+}
+
+.closeBtn:hover {
+	background: var(--bg-content);
+	color: var(--text-primary);
+}
+
+.form {
+	padding: 18px;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.inputGroup label {
+	display: block;
+	color: var(--text-secondary);
+	margin-bottom: 8px;
+	font-size: 14px;
+}
+
+.input {
+	width: 100%;
+	padding: 12px;
+	border-radius: 12px;
+	border: 1px solid var(--border-color);
+	background: var(--bg-surface);
+	color: var(--text-primary);
+	outline: none;
+	font-size: 15px;
+	transition: var(--transition-duration);
+}
+
+.input:focus {
+	border-color: var(--color-primary);
+	box-shadow: 0 0 0 2px var(--color-primary-light);
+}
+
+.inputError {
+	border-color: var(--color-red) !important;
+	background: rgba(239, 68, 68, 0.05);
+}
+
+.inputErrorMsg {
+	margin-top: 6px;
+	color: var(--color-red);
+	font-size: 13px;
+}
+
+.colorGrid {
+	display: flex;
+	justify-content: center;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.colorOption {
+	width: 23px;
+	height: 23px;
+	border-radius: 50%;
+	border: 2px solid transparent;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: transform 0.15s ease, box-shadow 0.15s ease;
+	flex-shrink: 0;
+}
+
+.colorOption:hover {
+	transform: scale(1.12);
+}
+
+.colorOption.selected {
+	box-shadow: 0 0 0 3px var(--bg-content), 0 0 0 5px currentColor;
+}
+
+.footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+	margin-top: 4px;
+}
+
+.btn {
+	border: none;
+	font-size: 14px;
+	padding: 10px 16px;
+	border-radius: 12px;
+	cursor: pointer;
+	transition: var(--transition-duration);
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.cancel {
+	background: transparent;
+	color: var(--text-secondary);
+}
+
+.cancel:hover {
+	background: var(--bg-surface);
+}
+
+.save {
+	background: var(--color-primary);
+	color: white;
+}
+
+.save:hover {
+	background: var(--color-primary-hover);
+}
+
+@keyframes fadeIn {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+@keyframes scaleIn {
+	from { transform: scale(0.95); opacity: 0; }
+	to { transform: scale(1); opacity: 1; }
+}
+
+@media (max-width: 480px) {
+	.overlay {
+		align-items: flex-end;
+	}
+
+	.modal {
+		width: min(440px, calc(100% - 24px));
+		margin-bottom: 16px;
+	}
+}

--- a/client/src/components/TagModal/TagModal.tsx
+++ b/client/src/components/TagModal/TagModal.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import { X, Check } from 'lucide-react';
+import type { Tag, TagColor } from '../../types';
+import styles from './TagModal.module.css';
+
+const ALLOWED_COLORS: TagColor[] = [
+  '#ef4444',
+  '#f97316',
+  '#eab308',
+  '#22c55e',
+  '#14b8a6',
+  '#3b82f6',
+  '#8b5cf6',
+  '#ec4899',
+  '#64748b',
+  '#84cc16',
+  '#06b6d4',
+  '#f43f5e',
+];
+
+interface TagModalProps {
+  tag?: Tag;
+  onSave: (name: string, color: string) => void;
+  onClose: () => void;
+}
+
+const TagModal = ({ tag, onSave, onClose }: TagModalProps) => {
+  const [name, setName] = useState(tag?.name ?? '');
+  const [selectedColor, setSelectedColor] = useState<string>(tag?.color ?? '#64748b');
+  const [nameError, setNameError] = useState('');
+
+  const validate = (value: string): string => {
+    if (!value.trim()) return 'Name is required';
+    if (value.length > 30) return 'Name must be 30 characters or less';
+    return '';
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const error = validate(name);
+    if (error) {
+      setNameError(error);
+      return;
+    }
+    onSave(name.trim(), selectedColor);
+  };
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h3 className={styles.title}>{tag ? 'Edit Tag' : 'Add New Tag'}</h3>
+          <button onClick={onClose} className={styles.closeBtn}>
+            <X size={20} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <div className={styles.inputGroup}>
+            <label htmlFor='tagName'>Name</label>
+            <input
+              id='tagName'
+              type='text'
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                if (nameError) setNameError(validate(e.target.value));
+              }}
+              className={`${styles.input} ${nameError ? styles.inputError : ''}`}
+              placeholder='e.g. urgent, idea, blocked...'
+              autoFocus
+              maxLength={30}
+            />
+            {nameError && <p className={styles.inputErrorMsg}>{nameError}</p>}
+          </div>
+
+          <div className={styles.inputGroup}>
+            <label>Color</label>
+            <div className={styles.colorGrid}>
+              {ALLOWED_COLORS.map((color) => (
+                <button
+                  key={color}
+                  type='button'
+                  className={`${styles.colorOption} ${selectedColor === color ? styles.selected : ''}`}
+                  style={{ backgroundColor: color }}
+                  onClick={() => setSelectedColor(color)}>
+                  {selectedColor === color && <Check size={14} color='white' strokeWidth={3} />}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.footer}>
+            <button type='button' onClick={onClose} className={`${styles.btn} ${styles.cancel}`}>
+              Cancel
+            </button>
+            <button type='submit' className={`${styles.btn} ${styles.save}`}>
+              {tag ? 'Save changes' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default TagModal;

--- a/client/src/components/TagModal/TagModal.tsx
+++ b/client/src/components/TagModal/TagModal.tsx
@@ -31,7 +31,10 @@ const TagModal = ({ tag, onSave, onClose }: TagModalProps) => {
 
   const validate = (value: string): string => {
     if (!value.trim()) return 'Name is required';
+    if (value.startsWith('#')) return 'Don\'t include the # — it\'s added automatically';
+    if (/\s/.test(value)) return 'Tag names cannot contain spaces';
     if (value.length > 30) return 'Name must be 30 characters or less';
+    if (!/^[\p{L}\p{N}_\-]+$/u.test(value.trim())) return 'Only letters, numbers, underscores and hyphens allowed';
     return '';
   };
 

--- a/client/src/components/TagModal/__tests__/TagModal.test.tsx
+++ b/client/src/components/TagModal/__tests__/TagModal.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TagModal from '../TagModal';
+
+function setup(tag?: { id: number; name: string; color: string }) {
+  const onSave = vi.fn();
+  const onClose = vi.fn();
+  render(<TagModal tag={tag} onSave={onSave} onClose={onClose} />);
+  return { onSave, onClose };
+}
+
+describe('TagModal — validation', () => {
+  it('shows "Name is required" when submitting empty form', async () => {
+    setup();
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+  });
+
+  it('shows error for name longer than 30 characters', async () => {
+    setup();
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'a'.repeat(31) } });
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText(/30 characters or less/i)).toBeInTheDocument();
+  });
+
+  it('shows error when name contains spaces', async () => {
+    setup();
+    await userEvent.type(screen.getByLabelText('Name'), 'my tag');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText(/cannot contain spaces/i)).toBeInTheDocument();
+  });
+
+  it('shows error when name starts with #', async () => {
+    setup();
+    await userEvent.type(screen.getByLabelText('Name'), '#urgent');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText(/added automatically/i)).toBeInTheDocument();
+  });
+
+  it('shows error for special characters other than _ and -', async () => {
+    setup();
+    await userEvent.type(screen.getByLabelText('Name'), 'tag@name');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText(/only letters/i)).toBeInTheDocument();
+  });
+
+  it('accepts underscores and hyphens', async () => {
+    const { onSave } = setup();
+    await userEvent.type(screen.getByLabelText('Name'), 'my_tag-name');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(onSave).toHaveBeenCalled();
+  });
+
+  it('clears error while typing a valid correction', async () => {
+    setup();
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText('Name'), 'urgent');
+    expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+  });
+});
+
+describe('TagModal — submission', () => {
+  it('calls onSave with trimmed name and selected color', async () => {
+    const { onSave } = setup();
+    await userEvent.type(screen.getByLabelText('Name'), 'urgent');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(onSave).toHaveBeenCalledWith('urgent', expect.any(String));
+  });
+
+  it('does not call onSave when name is invalid', async () => {
+    const { onSave } = setup();
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('shows "Save changes" button when editing an existing tag', () => {
+    setup({ id: 1, name: 'urgent', color: '#ef4444' });
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+  });
+
+  it('pre-fills name field when editing', () => {
+    setup({ id: 1, name: 'urgent', color: '#ef4444' });
+    expect(screen.getByLabelText('Name')).toHaveValue('urgent');
+  });
+});
+
+describe('TagModal — close behavior', () => {
+  it('calls onClose when Cancel is clicked', async () => {
+    const { onClose } = setup();
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when X button is clicked', async () => {
+    const { onClose } = setup();
+    const closeBtn = screen.getAllByRole('button').find(
+      (btn) => !btn.textContent?.includes('Create') && !btn.textContent?.includes('Cancel')
+    )!;
+    await userEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/client/src/components/ToDoItem/ToDoItem.module.css
+++ b/client/src/components/ToDoItem/ToDoItem.module.css
@@ -1,3 +1,28 @@
+.tagChipRow {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	padding: 0 14px 8px 14px;
+	position: relative;
+	z-index: 2;
+}
+
+.tagChip {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px 8px;
+	border-radius: 999px;
+	border: 1.5px solid;
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
+	max-width: 160px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	background: transparent;
+}
+
 .todoItem {
 	display: flex;
 	flex-direction: column;

--- a/client/src/components/ToDoItem/ToDoItem.module.css
+++ b/client/src/components/ToDoItem/ToDoItem.module.css
@@ -1,28 +1,3 @@
-.tagChipRow {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 4px;
-	padding: 0 14px 8px 14px;
-	position: relative;
-	z-index: 2;
-}
-
-.tagChip {
-	display: inline-flex;
-	align-items: center;
-	padding: 2px 8px;
-	border-radius: 999px;
-	border: 1.5px solid;
-	font-size: 11px;
-	font-weight: 500;
-	line-height: 1.4;
-	max-width: 160px;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	background: transparent;
-}
-
 .todoItem {
 	display: flex;
 	flex-direction: column;
@@ -69,7 +44,6 @@
 	pointer-events: none;
 }
 
-
 .clickable {
 	cursor: pointer;
 }
@@ -89,7 +63,6 @@
 	min-width: 0;
 }
 
-
 .todoCheckbox {
 	width: 24px;
 	height: 24px;
@@ -101,7 +74,11 @@
 	justify-content: center;
 	align-items: center;
 	cursor: pointer;
-	transition: background var(--transition), border-color var(--transition), transform var(--transition), box-shadow var(--transition);
+	transition:
+		background var(--transition),
+		border-color var(--transition),
+		transform var(--transition),
+		box-shadow var(--transition);
 }
 
 .todoCheckbox:hover {
@@ -149,7 +126,6 @@
 	padding-right: 50px;
 }
 
-
 .todoText {
 	display: flex;
 	align-items: center;
@@ -171,7 +147,6 @@
 	text-overflow: ellipsis;
 	min-width: 0;
 }
-
 
 .todoDescriptionExpanded {
 	font-size: 14px;
@@ -536,6 +511,31 @@
 	cursor: pointer;
 }
 
+.tagChipRow {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+	padding: 0px 0px 0px 0px;
+	position: relative;
+	z-index: 2;
+}
+
+.tagChip {
+	display: inline-flex;
+	align-items: center;
+	padding: 2px 8px;
+	border-radius: 999px;
+	border: 1.5px solid;
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.4;
+	max-width: 160px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	background: transparent;
+}
+
 @media (max-width: 767px) {
 	.calendarOverlay {
 		align-items: flex-end;
@@ -571,12 +571,15 @@
 		opacity: 1;
 		pointer-events: auto;
 	}
-
 }
 
 @keyframes fadeIn {
-	from { opacity: 0; }
-	to   { opacity: 1; }
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
 }
 
 @keyframes fadeSlideIn {
@@ -591,22 +594,50 @@
 }
 
 @keyframes checkBounce {
-	0%   { transform: scale(1); }
-	40%  { transform: scale(1.3); }
-	70%  { transform: scale(0.9); }
-	100% { transform: scale(1); }
+	0% {
+		transform: scale(1);
+	}
+	40% {
+		transform: scale(1.3);
+	}
+	70% {
+		transform: scale(0.9);
+	}
+	100% {
+		transform: scale(1);
+	}
 }
 
-.todoItem:nth-child(1)  { animation-delay: 0ms; }
-.todoItem:nth-child(2)  { animation-delay: 40ms; }
-.todoItem:nth-child(3)  { animation-delay: 80ms; }
-.todoItem:nth-child(4)  { animation-delay: 120ms; }
-.todoItem:nth-child(5)  { animation-delay: 160ms; }
-.todoItem:nth-child(6)  { animation-delay: 200ms; }
-.todoItem:nth-child(7)  { animation-delay: 240ms; }
-.todoItem:nth-child(8)  { animation-delay: 280ms; }
-.todoItem:nth-child(9)  { animation-delay: 320ms; }
-.todoItem:nth-child(10) { animation-delay: 360ms; }
+.todoItem:nth-child(1) {
+	animation-delay: 0ms;
+}
+.todoItem:nth-child(2) {
+	animation-delay: 40ms;
+}
+.todoItem:nth-child(3) {
+	animation-delay: 80ms;
+}
+.todoItem:nth-child(4) {
+	animation-delay: 120ms;
+}
+.todoItem:nth-child(5) {
+	animation-delay: 160ms;
+}
+.todoItem:nth-child(6) {
+	animation-delay: 200ms;
+}
+.todoItem:nth-child(7) {
+	animation-delay: 240ms;
+}
+.todoItem:nth-child(8) {
+	animation-delay: 280ms;
+}
+.todoItem:nth-child(9) {
+	animation-delay: 320ms;
+}
+.todoItem:nth-child(10) {
+	animation-delay: 360ms;
+}
 
 @keyframes scaleIn {
 	from {

--- a/client/src/components/ToDoItem/ToDoItem.tsx
+++ b/client/src/components/ToDoItem/ToDoItem.tsx
@@ -4,7 +4,7 @@ import { DayPicker } from 'react-day-picker';
 import PomodoroTimer from '../PomodoroTimer';
 import { startPomodoro, getPomodoro } from '../../api/taskApi';
 import { useAuth } from '../../context/AuthContext';
-import type { Task, PomoData, Category } from '../../types';
+import type { Task, PomoData, Category, Tag } from '../../types';
 import { useSortable } from '@dnd-kit/react/sortable';
 
 import {
@@ -36,6 +36,7 @@ interface ToDoItemProps {
   activePomoData: PomoData | null;
   setActivePomoData: (data: PomoData | null) => void;
   categories: Category[];
+  tags: Tag[];
 }
 
 const ToDoItem = ({
@@ -50,6 +51,7 @@ const ToDoItem = ({
   activePomoData,
   setActivePomoData,
   categories,
+  tags,
 }: ToDoItemProps) => {
   const { user } = useAuth();
   const { ref, isDragSource } = useSortable({ id: task.id, index, disabled: !draggable });
@@ -62,6 +64,9 @@ const ToDoItem = ({
 
   const effectiveDueDate = dueDate ?? (task.scheduled ? new Date(task.scheduled) : null);
   const resolvedCategory = categories.find((c) => c.id === task.categoryId) ?? task.category ?? null;
+  const resolvedTags = (task.tags ?? [])
+    .map((t) => tags.find((x) => x.id === t.id))
+    .filter((t): t is Tag => t !== undefined);
 
   const categoryGradient = resolvedCategory
     ? (() => {
@@ -242,6 +247,19 @@ const ToDoItem = ({
           </div>
         </div>
 
+        {resolvedTags.length > 0 && (
+          <div className={styles.tagChipRow} onPointerDown={(e) => e.stopPropagation()}>
+            {resolvedTags.map((tag) => (
+              <span
+                key={tag.id}
+                className={styles.tagChip}
+                style={{ borderColor: tag.color, color: tag.color }}>
+                #{tag.name}
+              </span>
+            ))}
+          </div>
+        )}
+
         <div className={`${styles['descriptionWrapper']} ${isExpanded ? styles.open : ''}`}>
           <div className={`${styles['todoDescriptionExpanded']} ${task.done ? styles.done : ''}`}>
             {task.description}
@@ -255,6 +273,7 @@ const ToDoItem = ({
           onUpdate={(id, updates) => onEdit(id, updates)}
           onClose={() => setShowEditModal(false)}
           categories={categories}
+          tags={tags}
         />
       )}
 

--- a/client/src/pages/MainContent/MainContent.tsx
+++ b/client/src/pages/MainContent/MainContent.tsx
@@ -6,6 +6,7 @@ import ActiveTasks from '../../components/ActiveTasks';
 import CompletedTasks from '../../components/CompletedTasks/CompletedTasks';
 import UserSettings from '../../components/UserSettings/UserSettings';
 import CategoryModal from '../../components/CategoryModal/CategoryModal';
+import TagModal from '../../components/TagModal/TagModal';
 import { getPomodoro } from '../../api/taskApi';
 import {
   fetchCategories,
@@ -13,9 +14,10 @@ import {
   updateCategory,
   deleteCategory,
 } from '../../api/categoryApi';
+import { fetchTags, createTag, updateTag, deleteTag } from '../../api/tagApi';
 import { useAuth } from '../../context/AuthContext';
 import { updateUserSettings } from '../../api/auth';
-import type { PomoData, Category } from '../../types';
+import type { PomoData, Category, Tag } from '../../types';
 
 type Tab = 'active' | 'completed' | 'settings';
 
@@ -54,13 +56,24 @@ const MainContent = () => {
   const [showCategoryModal, setShowCategoryModal] = useState(false);
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
 
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
+  const [showTagModal, setShowTagModal] = useState(false);
+  const [editingTag, setEditingTag] = useState<Tag | null>(null);
+
   const loadCategories = async () => {
     const data = await fetchCategories();
     setCategories(data);
   };
 
+  const loadTags = async () => {
+    const data = await fetchTags();
+    setTags(data);
+  };
+
   useEffect(() => {
     loadCategories();
+    loadTags();
   }, []);
 
   const handleCategorySelect = (id: number | null) => {
@@ -94,6 +107,41 @@ const MainContent = () => {
     await loadCategories();
   };
 
+  const handleTagToggle = (id: number) => {
+    setSelectedTagIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+    setActiveTab('active');
+  };
+
+  const handleTagsClear = () => setSelectedTagIds([]);
+
+  const handleTagCreate = () => {
+    setEditingTag(null);
+    setShowTagModal(true);
+  };
+
+  const handleTagEdit = (tag: Tag) => {
+    setEditingTag(tag);
+    setShowTagModal(true);
+  };
+
+  const handleTagDelete = async (id: number) => {
+    await deleteTag(id);
+    setSelectedTagIds((prev) => prev.filter((x) => x !== id));
+    await loadTags();
+  };
+
+  const handleTagSave = async (name: string, color: string) => {
+    if (editingTag) {
+      await updateTag(editingTag.id, { name, color });
+    } else {
+      await createTag(name, color);
+    }
+    setShowTagModal(false);
+    await loadTags();
+  };
+
   const renderContent = () => {
     switch (activeTab) {
       case 'active':
@@ -105,10 +153,12 @@ const MainContent = () => {
             setActivePomoData={setActivePomoData}
             categories={categories}
             selectedCategoryId={selectedCategoryId}
+            tags={tags}
+            selectedTagIds={selectedTagIds}
           />
         );
       case 'completed':
-        return <CompletedTasks categories={categories} />;
+        return <CompletedTasks categories={categories} tags={tags} />;
       case 'settings':
         return <UserSettings isFullscreen={isFullscreen} setIsFullscreen={setIsFullscreen} />;
       default:
@@ -163,6 +213,13 @@ const MainContent = () => {
               onCategoryCreate={handleCategoryCreate}
               onCategoryUpdate={handleCategoryUpdate}
               onCategoryDelete={handleCategoryDelete}
+              tags={tags}
+              selectedTagIds={selectedTagIds}
+              onTagToggle={handleTagToggle}
+              onTagsClear={handleTagsClear}
+              onTagCreate={handleTagCreate}
+              onTagEdit={handleTagEdit}
+              onTagDelete={handleTagDelete}
             />
 
             <main className={styles.dashboardContent}>{renderContent()}</main>
@@ -175,6 +232,14 @@ const MainContent = () => {
           category={editingCategory ?? undefined}
           onSave={handleCategorySave}
           onClose={() => setShowCategoryModal(false)}
+        />
+      )}
+
+      {showTagModal && (
+        <TagModal
+          tag={editingTag ?? undefined}
+          onSave={handleTagSave}
+          onClose={() => setShowTagModal(false)}
         />
       )}
     </div>

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -36,6 +36,17 @@ export type CategoryColor =
   | '#06b6d4'
   | '#f43f5e';
 
+export interface Tag {
+  id: number;
+  name: string;
+  color: string;
+  _count?: { tasks: number };
+}
+
+export type TagColor = CategoryColor;
+
+export const MAX_TAGS_PER_TASK = 10;
+
 export type CategoryIcon =
   | 'Briefcase'
   | 'Home'
@@ -68,6 +79,7 @@ export interface Task {
   categoryId: number | null;
   category: Category | null;
   sortOrder: number;
+  tags?: Tag[];
 }
 
 export interface PomoData {


### PR DESCRIPTION
Implement full client-side tag support to match the existing backend API:

  - Tag CRUD via new tagApi.ts (create, edit, delete, assign/remove from tasks)
  - Tags section in Sidebar with multi-select filtering (OR semantics) and a Clear button
  - TagModal for creating/editing tags — name (max 30 chars) + 12-color picker
  - TagChipPicker shared component used in Add/Edit Task modals — chip multi-select, capped at 10 per task, shows warning only when limit is reached
  - Tag chips rendered on each task as outlined colored pills (border + text only, no fill)
  - Tag deletion immediately removes badges from all visible tasks (client-side filter against live tags array)
  - Tag filter combined with category filter client-side (intersection)
  - fetchTasks updated to map tags from server response

Check if current setup is okay - let me now if I shoudl change something. Tested manually - looks ok.